### PR TITLE
minor `t/` fixups

### DIFF
--- a/t/test-conflicted
+++ b/t/test-conflicted
@@ -5,7 +5,7 @@
 set -e
 set -x
 
-GIT_IMERGE="../git/git-imerge"
+GIT_IMERGE="../git-imerge"
 
 # Clean up detritus from possible previous runs:
 git checkout master

--- a/t/test-conflictless
+++ b/t/test-conflictless
@@ -5,7 +5,7 @@
 set -e
 set -x
 
-GIT_IMERGE="../git/git-imerge"
+GIT_IMERGE="../git-imerge"
 
 # Clean up detritus from possible previous runs:
 git checkout master


### PR DESCRIPTION
I couldn't run the test scripts out of the box; these fixups let me at least run it (and it _looks_ like it all worked :) ).

Two other improvements I noticed while running the tests but didn't put into this series (because they are part of much larger issues):
1. The `git-imerge` script points statically at `/usr/bin/python2`. On my Debian system, it's `/usr/bin/python`. If we want to allow both, I guess we'd need some kind of build infrastructure.
2. The test scripts seem to want to be run in the current directory; but after running, you now have a .git directory in `t/`, which makes it hard to commit any improvements. Maybe I'm doing it wrong, but if not, doing it all in a trash directory would make sense. But of course that would probably be part of a larger test harness.
