### PR TITLE
Use python2 from environment

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#! /usr/bin/env python2
 
 # Copyright 2012-2013 Michael Haggerty <mhagger@alum.mit.edu>
 #


### PR DESCRIPTION
Some environments might have a old and/or broken version of python2
installed in /usr/bin but still wish to use git-imerge. The non-broken
version of python might be loaded separately from the base operating
system image via for example environment modules [1].

So use the currently active python2 from the environment instead of
hard coding the path to /usr/bin/python2.

[1] http://modules.sourceforge.net/
