### PR TITLE
Retain author information during --goal=rebase

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -128,6 +128,7 @@ import functools
 import argparse
 from cStringIO import StringIO
 import json
+import os
 
 # CalledProcessError, check_call, and check_output were not in the
 # original Python 2.4 subprocess library, so implement it here if
@@ -367,6 +368,21 @@ def get_log_message(commit):
     if contents and contents[-1][-1:] != '\n':
         contents.append('\n')
     return ''.join(contents)
+
+
+def get_commit_info(commit):
+    a = check_output([
+        'git', 'log', '-n1',
+        '--format=%an%x1d%ae%x1d%at%x1d%cn%x1d%ce%x1d%ct', commit
+    ]).strip().split('\x1d')
+
+    return {'GIT_AUTHOR_NAME': a[0],
+            'GIT_AUTHOR_EMAIL': a[1],
+            'GIT_AUTHOR_DATE': a[2],
+            'GIT_COMMITTER_NAME': a[3],
+            'GIT_COMMITTER_EMAIL': a[4],
+            'GIT_COMMITTER_DATE': a[5],
+            }
 
 
 class TemporaryHead(object):
@@ -1948,13 +1964,15 @@ class MergeState(Block):
         for i2 in range(1, self.len2):
             orig = self[0, i2].sha1
             tree = get_tree(self[i1, i2].sha1)
+            authordata = get_commit_info(orig)
 
             # Create a commit, copying the old log message:
             commit = check_output([
                     'git', 'commit-tree',
                     '-m', get_log_message(orig),
                     '-p', commit, '-p', orig, tree,
-                    ]).strip()
+                    ], env=dict(os.environ.items() + authordata.items())
+            ).strip()
 
         self._set_refname(refname, commit, force=force)
 
@@ -1971,13 +1989,15 @@ class MergeState(Block):
         for i2 in range(1, self.len2):
             orig = self[0, i2].sha1
             tree = get_tree(self[i1, i2].sha1)
+            authordata = get_commit_info(orig)
 
             # Create a commit, copying the old log message:
             commit = check_output([
                     'git', 'commit-tree',
                     '-m', get_log_message(orig),
                     '-p', commit, tree,
-                    ]).strip()
+                    ], env=dict(os.environ.items() + authordata.items())
+            ).strip()
 
         self._set_refname(refname, commit, force=force)
 


### PR DESCRIPTION
Using %x1d might be wrong, I keep getting my ascii separators mixed up, maybe null would be better.
