### PR TITLE
Makefile: add 'install' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+prefix = $(HOME)
+bindir = $(prefix)/bin
+
+INSTALL = install
+
 RST := \
     README.rst \
     TODO.rst
@@ -17,3 +22,6 @@ html: $(module)/talk.html
 $(module)/talk.html: $(module)/talk.rst
 	rst2s5 --theme=small-white --current-slide $< $@
 
+install: all
+	$(INSTALL) -d -m 755 '$(bindir)'
+	$(INSTALL) -m 755 git-imerge '$(bindir)'


### PR DESCRIPTION
Run `make install` or `make prefix=... install`
to install 'git-imerge' on your system.
