### PR TITLE
get_author_info(): Don't use use magic separator characted (NUL)

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -390,10 +390,10 @@ def get_author_info(commit):
 
     Return a map {str : str}."""
 
-    a = check_output([
-        'git', '--no-pager', 'log', '-n1',
-        '--format=%an%x00%ae%x00%ai', commit
-        ]).strip().split('\x00')
+    a = map(
+        lambda fmt: check_output(['git', '--no-pager', 'log', '-n1', '--format=' + fmt, commit]).strip(),
+        ["%an", "%ae", "%ai"]
+        )
 
     return {
         'GIT_AUTHOR_NAME': env_encode(a[0]),


### PR DESCRIPTION
This works around a problem with msysgit, where the NUL character
somehow causes the rest of the line to get lost.

Now running the tests from a cywgin shell with msysgit git.exe
in the PATH completes without errors.