### PR TITLE
MergeFrontier.compute_by_bisection(): Be optimistic!

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -962,6 +962,10 @@ class MergeFrontier(object):
         if block.len1 <= 1 or block.len2 <= 1 or block.is_blocked(1, 1):
             return MergeFrontier(block, [])
 
+        if block.is_mergeable(block.len1 - 1, block.len2 - 1):
+            # The whole block is mergable!
+            return MergeFrontier(block, [block])
+
         if not block.is_mergeable(1, 1):
             # There are no mergeable blocks in block; therefore,
             # block[1,1] must itself be unmergeable.  Record that


### PR DESCRIPTION
When trying to find the merge frontier within a block, first try the bottom-right corner of the block in the hope that the whole block is already mergeable. The hope is that it is true relatively frequently, sparing a bunch of bisection.

Fixes #59.

Issue #59 suggests some other changes to the algorithm that might improve the situation even more. But this first step probably grabs most of the benefit already.

...if indeed it is a benefit in typical real-world scenarios.
