### PR TITLE
bash-completion: bash3 compatibility

### DIFF
--- a/git-imerge.bashcomplete
+++ b/git-imerge.bashcomplete
@@ -244,6 +244,11 @@ _git_imerge () {
 	type compopt >/dev/null 2>&1 && compopt +o default +o bashdefault
 
 	local i command cur_opt
+
+	# find which git-imerge subcommand is on the line
+	# For example:
+	# words=(git imerge start master)
+	# command="start"
 	for ((i=0; i <= ${cword}; i++)); do
 		if [ -n "$command" ] && [ "${words[i]}" != "$cur" ]; then
 			cur_opt="${words[i]}"

--- a/git-imerge.bashcomplete
+++ b/git-imerge.bashcomplete
@@ -249,7 +249,11 @@ _git_imerge () {
 	# For example:
 	# words=(git imerge start master)
 	# command="start"
-	for ((i=0; i <= ${cword}; i++)); do
+	#
+	# Start looking at index 1 because the logic can be simpler when
+	# it assumes that "imerge" will always be in the position before
+	# the subcommand.
+	for ((i=1; i <= ${cword}; i++)); do
 		if [ -n "$command" ] && [ "${words[i]}" != "$cur" ]; then
 			cur_opt="${words[i]}"
 		fi


### PR DESCRIPTION
The negative indexes were happening under bash4 as well, but didn't show any obvious symptoms.

I've also added some explanatory text -- hopefully I've interpreted the code's intention properly.

Addresses issue #86 (Completion errors under bash 3.x)