### PR TITLE
New concept: "simplify to path"

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -576,6 +576,23 @@ class TemporaryHead(object):
         return False
 
 
+def is_ff(refname, commit):
+    """Would updating refname to commit be a fast-forward update?
+
+    Return True iff refname is not currently set or it points to an
+    ancestor of commit.
+
+    """
+
+    try:
+        ref_oldval = get_commit_sha1(refname)
+    except ValueError:
+        # refname doesn't already exist; no problem.
+        return True
+    else:
+        return MergeState._is_ancestor(ref_oldval, commit)
+
+
 def reparent(commit, parent_sha1s, msg=None):
     """Create a new commit object like commit, but with the specified parents.
 
@@ -2461,28 +2478,23 @@ class MergeState(Block):
                     )
             path.append((record.sha1, self[0, i2].sha1))
 
-        if not force:
-            # A rebase simplification is allowed to discard history,
-            # as long as the *pre-simplification* apex commit is a
-            # descendant of the branch to be moved.
-            try:
-                ref_oldval = get_commit_sha1(refname)
-            except ValueError:
-                # refname doesn't already exist; no problem.
-                pass
-            else:
-                commit = self[-1, -1].sha1
-                if not MergeState._is_ancestor(ref_oldval, commit):
-                    raise Failure(
-                        '%s is not an ancestor of %s; use --force if you are sure'
-                        % (commit, refname,)
-                        )
+        # A rebase simplification is allowed to discard history, as
+        # long as the *pre-simplification* apex commit is a descendant
+        # of the branch to be moved.
+        apex = self[-1, -1].sha1
+        if not force and not is_ff(refname, apex):
+            raise Failure(
+                '%s cannot be updated to %s without discarding history.\n'
+                'Use --force if you are sure, or choose a different reference'
+                % (refname, apex,)
+                )
 
-        commit = create_commit_chain(self[i1, 0].sha1, path)
-
-        # We checked above that the update is OK, so here we can set
-        # force=True:
-        self._set_refname(refname, commit, force=True)
+        # The update is OK, so here we can set force=True:
+        self._set_refname(
+            refname,
+            create_commit_chain(self[i1, 0].sha1, path),
+            force=True,
+            )
 
     def simplify_to_merge(self, refname, force=False):
         if not (-1, -1) in self:

--- a/git-imerge
+++ b/git-imerge
@@ -139,8 +139,6 @@ class Failure(Exception):
 
         return wrapper
 
-    pass
-
 
 class AnsiColor:
     BLACK = '\033[0;30m'

--- a/git-imerge
+++ b/git-imerge
@@ -625,6 +625,53 @@ def reparent(commit, parent_sha1s, msg=None):
     return out.strip()
 
 
+def create_commit_chain(base, path):
+    """Point refname at the chain of commits indicated by path.
+
+    path is a list [(commit, metadata), ...]. Create a series of
+    commits corresponding to the entries in path. Each commit's tree
+    is taken from the corresponding old commit, and each commit's
+    metadata is taken from the corresponding metadata commit. Use base
+    as the parent of the first commit, or make the first commit a root
+    commit if base is None. Reuse existing commits from the list
+    whenever possible.
+
+    Return a commit object corresponding to the last commit in the
+    chain.
+
+    """
+
+    reusing = True
+    if base is None:
+        if not path:
+            raise ValueError('neither base nor path specified')
+        parents = []
+    else:
+        parents = [base]
+
+    for (commit, metadata) in path:
+        if reusing:
+            if commit == metadata and get_commit_parents(commit) == parents:
+                # We can reuse this commit, too.
+                parents = [commit]
+                continue
+            else:
+                reusing = False
+
+        # Create a commit, copying the old log message and author info
+        # from the metadata commit:
+        tree = get_tree(commit)
+        new_commit = commit_tree(
+            tree, parents,
+            msg=get_log_message(metadata),
+            metadata=get_author_info(metadata),
+            )
+        parents = [new_commit]
+
+    [commit] = parents
+    return commit
+
+
 class AutomaticMergeFailed(Exception):
     def __init__(self, commit1, commit2):
         Exception.__init__(
@@ -2404,12 +2451,15 @@ class MergeState(Block):
 
     def simplify_to_rebase(self, refname, force=False):
         i1 = self.len1 - 1
+        path = []
         for i2 in range(1, self.len2):
-            if not (i1, i2) in self:
+            record = self[i1, i2]
+            if not record.is_known():
                 raise Failure(
                     'Cannot simplify to rebase because merge %d-%d is not yet done'
                     % (i1, i2)
                     )
+            path.append((record.sha1, self[0, i2].sha1))
 
         if not force:
             # A rebase simplification is allowed to discard history,
@@ -2428,16 +2478,7 @@ class MergeState(Block):
                         % (commit, refname,)
                         )
 
-        commit = self[i1, 0].sha1
-        for i2 in range(1, self.len2):
-            orig = self[0, i2].sha1
-            tree = get_tree(self[i1, i2].sha1)
-            authordata = get_author_info(orig)
-
-            # Create a commit, copying the old log message and author info:
-            commit = commit_tree(
-                tree, [commit], msg=get_log_message(orig), metadata=authordata,
-                )
+        commit = create_commit_chain(self[i1, 0].sha1, path)
 
         # We checked above that the update is OK, so here we can set
         # force=True:

--- a/git-imerge
+++ b/git-imerge
@@ -1909,6 +1909,13 @@ class SubBlock(Block):
             )
 
 
+class MissingMergeFailure(Failure):
+    def __init__(self, i1, i2):
+        Failure.__init__(self, 'Merge %d-%d is not yet done' % (i1, i2))
+        self.i1 = i1
+        self.i2 = i2
+
+
 class MergeState(Block):
     SOURCE_TABLE = {
         'auto': MergeRecord.SAVED_AUTO,
@@ -2466,22 +2473,34 @@ class MergeState(Block):
 
         self._set_refname(refname, commit, force=force)
 
-    def simplify_to_rebase(self, refname, force=False):
-        i1 = self.len1 - 1
-        path = []
-        for i2 in range(1, self.len2):
-            record = self[i1, i2]
-            if not record.is_known():
-                raise Failure(
-                    'Cannot simplify to rebase because merge %d-%d is not yet done'
-                    % (i1, i2)
-                    )
-            path.append((record.sha1, self[0, i2].sha1))
+    def _simplify_to_path(self, refname, base, path, force=False):
+        """Simplify based on path and set refname to the result.
 
-        # A rebase simplification is allowed to discard history, as
-        # long as the *pre-simplification* apex commit is a descendant
-        # of the branch to be moved.
-        apex = self[-1, -1].sha1
+        The base and path arguments are defined similarly to
+        create_commit_chain(), except that instead of SHA-1s they
+        represent commits via (i1, i2) tuples.
+
+        """
+
+        base_sha1 = self[base].sha1
+        path_sha1 = []
+        for (commit, metadata) in path:
+            commit_record = self[commit]
+            if not commit_record.is_known():
+                raise MissingMergeFailure(*commit)
+            metadata_record = self[metadata]
+            if not metadata_record.is_known():
+                raise MissingMergeFailure(*metadata_record)
+            path_sha1.append((commit_record.sha1, metadata_record.sha1))
+
+        # A path simplification is allowed to discard history, as long
+        # as the *pre-simplification* apex commit is a descendant of
+        # the branch to be moved.
+        if path:
+            apex = path_sha1[-1][0]
+        else:
+            apex = base_sha1
+
         if not force and not is_ff(refname, apex):
             raise Failure(
                 '%s cannot be updated to %s without discarding history.\n'
@@ -2492,9 +2511,24 @@ class MergeState(Block):
         # The update is OK, so here we can set force=True:
         self._set_refname(
             refname,
-            create_commit_chain(self[i1, 0].sha1, path),
+            create_commit_chain(base_sha1, path_sha1),
             force=True,
             )
+
+    def simplify_to_rebase(self, refname, force=False):
+        i1 = self.len1 - 1
+        path = [
+            ((i1, i2), (0, i2))
+            for i2 in range(1, self.len2)
+            ]
+
+        try:
+            self._simplify_to_path(refname, (i1, 0), path, force=force)
+        except MissingMergeFailure as e:
+            raise Failure(
+                'Cannot simplify to rebase because merge %d-%d is not yet done'
+                % (e.i1, e.i2)
+                )
 
     def simplify_to_merge(self, refname, force=False):
         if not (-1, -1) in self:


### PR DESCRIPTION
The last step of "simplify to rebase" is chaining a bunch of commits from the merge diagram into a linear history, taking the metadata for the new commits from the metadata for the corresponding original commits. Currently that is done using specialized code.

But this procedure can be generalized. Add a new function `create_commit_chain()` that can string an arbitrary list of commits together using arbitrary commits as the source of the metadata. Also add a method `MergeState._simplify_to_path()` that can do the same thing using commits taken from a `MergeState`.

Rewrite `MergeState.simplify_to_rebase()` to use the new functions.

This will make it easier to add other new functionality (not part of this PR):

* The new "simplify to rebase reversed" feature suggested in #89. In this case we need to chain together the commits from the bottom edge of the merge diagram rather than the right edge.
* Dropping commits that don't do anything. Often the same logical change is made on both of the branches, with the result that one of the commits in the rebased branch doesn't do anything. `git rebase` allows such commits to be omitted from the rebased result, and we should too.
* Incremental `git revert`. Reverting one or more commits from your current branch can result in merge conflicts just like merging or rebasing. But these conflicts can be resolved in an incremental way using the approach discussed [here](https://github.com/mhagger/git-imerge/issues/20#issuecomment-21297035). "Simplify to path" could be used to string the results together while omitting the unwanted commits and their inverses.
* `git rebase --onto` is quite a bit like the previous case, followed by appending more commits to the end of the second branch, as described [midway through this comment](https://github.com/mhagger/git-imerge/issues/20#issuecomment-36331551). For that matter, some uses of `git cherry-pick` are equivalent to `git rebase --onto`, though I doubt that many scenarios thought of as cherry-picking would be practical to do incrementally.
* We could make it possible to break off an incremental merge before all of the conflicts are resolved, resulting (for example) in a branch being rebased not to the tip of the target branch, but rather to partway along the target branch. This would be a way to "lock in" part of the work of a rebase/merge.
* For a completed full incremental merge, the commits from the two branches can be interleaved in arbitrary order by chaining together commits along any zig-zag path that starts at the upper-left and ends at the lower-right of the diagram. I'm not sure that this is useful though, given that it requires the full incremental merge to be completed first, and that is usually quite expensive.

This change is only very lightly tested. (We need better tests!)
