### PR TITLE
Make it easier to create a RPM package by honouring DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ install: $(BIN)
 	cp -f git-imerge.bashcomplete $(DESTDIR)/etc/bash_completion.d/git-imerge
 
 uninstall:
-	rm $(PREFIX)/bin/$(BIN)
-	rm -f /etc/bash_completion.d/git-imerge
+	rm $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	rm -f $(DESTDIR)/etc/bash_completion.d/git-imerge

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ $(module)/talk.html: $(module)/talk.rst
 	rst2s5 --theme=small-white --current-slide $< $@
 
 install: $(BIN)
-	install $(BIN) $(PREFIX)/bin
-	@mkdir -p /etc/bash_completion.d
-	cp -f git-imerge.bashcomplete /etc/bash_completion.d/git-imerge
+	@mkdir -p $(DESTDIR)$(PREFIX)/bin
+	install $(BIN) $(DESTDIR)$(PREFIX)/bin
+	@mkdir -p $(DESTDIR)/etc/bash_completion.d
+	cp -f git-imerge.bashcomplete $(DESTDIR)/etc/bash_completion.d/git-imerge
 
 uninstall:
 	rm $(PREFIX)/bin/$(BIN)

--- a/git-imerge.bashcomplete
+++ b/git-imerge.bashcomplete
@@ -1,5 +1,3 @@
-#!bash
-
 __git_imerge_branches () {
 	git for-each-ref --format='%(refname)' refs/heads/ refs/remotes/ 2>/dev/null |
 	sed -e 's!^refs/heads/!!' -e 's!^refs/remotes/!!'


### PR DESCRIPTION
Also fixed a rpmlint warning in the bash-completion script