### PR TITLE
Support autocommitting merges with no changes

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -379,6 +379,18 @@ def rev_list(*args):
         ]
 
 
+git_dir_cache = None
+
+def git_dir():
+    global git_dir_cache
+
+    if git_dir_cache is None:
+        git_dir_cache = check_output(
+            ['git', 'rev-parse', '--git-dir']
+            ).rstrip('\n')
+    return git_dir_cache
+
+
 def get_type(arg):
     """Return the type of a git object ('commit', 'tree', 'blob', or 'tag')."""
 
@@ -2590,19 +2602,39 @@ def request_user_merge(merge_state, i1, i2):
         )
 
 
-def commit_user_merge(merge_state, edit_log_msg=None):
-    """If there is staged content that is ready to be committed, do so.
-
-    If there is staged content that is ready to be committed, commit
-    it and return True; otherwise, return False."""
-
+def simple_merge_in_progress():
+    # Check if a merge (of a single branch) is in progress:
     try:
-        check_call(['git', 'diff-index', '--cached', '--quiet', 'HEAD', '--'])
+        with open(os.path.join(git_dir(), 'MERGE_HEAD')) as f:
+            heads = [line.rstrip() for line in f]
+    except IOError:
         return False
-    except CalledProcessError:
-        pass
 
-    # There are staged changes; commit them if possible.
+    return len(heads) == 1
+
+
+def commit_user_merge(merge_state, edit_log_msg=None):
+    """If a merge is in progress and ready to be committed, commit it.
+
+    If a simple merge is in progress and any changes in the working
+    tree are staged, commit the merge commit and return True.
+    Otherwise, return False.
+
+    """
+
+    if not simple_merge_in_progress():
+        return False
+
+    # Check if all conflicts are resolved and everything in the
+    # working tree is staged:
+    refresh_index()
+    if unstaged_changes():
+        raise UncleanWorkTreeError(
+            'Cannot proceed: You have unstaged changes.' % (action,)
+            )
+
+    # A merge is in progress, and either all changes have been staged
+    # or no changes are necessary. Create a merge commit.
     cmd = ['git', 'commit', '--no-verify']
 
     if edit_log_msg is None:

--- a/git-imerge
+++ b/git-imerge
@@ -2570,6 +2570,37 @@ def request_user_merge(merge_state, i1, i2):
         )
 
 
+def commit_user_merge(merge_state, edit_log_msg=None):
+    """If there is staged content that is ready to be committed, do so.
+
+    If there is staged content that is ready to be committed, commit
+    it and return True; otherwise, return False."""
+
+    try:
+        check_call(['git', 'diff-index', '--cached', '--quiet', 'HEAD', '--'])
+        return False
+    except CalledProcessError:
+        pass
+
+    # There are staged changes; commit them if possible.
+    cmd = ['git', 'commit', '--no-verify']
+
+    if edit_log_msg is None:
+        edit_log_msg = get_default_edit()
+
+    if edit_log_msg:
+        cmd += ['--edit']
+    else:
+        cmd += ['--no-edit']
+
+    try:
+        check_call(cmd)
+    except CalledProcessError:
+        raise Failure('Could not commit staged changes.')
+
+    return True
+
+
 def incorporate_user_merge(merge_state, edit_log_msg=None):
     """If the user has done a merge for us, incorporate the results.
 
@@ -2641,30 +2672,12 @@ def incorporate_user_merge(merge_state, edit_log_msg=None):
     # If we reach this point, then the scratch reference exists and is
     # checked out.  Now check whether there is staged content that
     # can be committed:
-
-    merge_frontier = MergeFrontier.map_known_frontier(merge_state)
-
-    try:
-        check_call(['git', 'diff-index', '--cached', '--quiet', 'HEAD', '--'])
-    except CalledProcessError:
-        # There are staged changes; commit them if possible.
-        cmd = ['git', 'commit', '--no-verify']
-
-        if edit_log_msg is None:
-            edit_log_msg = get_default_edit()
-
-        if edit_log_msg:
-            cmd += ['--edit']
-        else:
-            cmd += ['--no-edit']
-
-        try:
-            check_call(cmd)
-        except CalledProcessError:
-            raise Failure('Could not commit staged changes.')
+    if commit_user_merge(merge_state, edit_log_msg=edit_log_msg):
         commit = get_commit_sha1('HEAD')
 
     require_clean_work_tree('proceed')
+
+    merge_frontier = MergeFrontier.map_known_frontier(merge_state)
 
     # This might throw ManualMergeUnusableError:
     (i1, i2) = merge_state.incorporate_manual_merge(commit)

--- a/git-imerge
+++ b/git-imerge
@@ -309,6 +309,19 @@ def unstaged_changes():
         return True
 
 
+def uncommitted_changes():
+    """Return True iff the index contains uncommitted changes."""
+
+    try:
+        check_call([
+            'git', 'diff-index', '--cached', '--quiet',
+            '--ignore-submodules', 'HEAD', '--',
+            ])
+        return False
+    except CalledProcessError:
+        return True
+
+
 def require_clean_work_tree(action):
     """Verify that the current tree is clean.
 
@@ -330,12 +343,7 @@ def require_clean_work_tree(action):
     if unstaged_changes():
         error.append('Cannot %s: You have unstaged changes.' % (action,))
 
-    try:
-        check_call([
-            'git', 'diff-index', '--cached', '--quiet',
-            '--ignore-submodules', 'HEAD', '--',
-            ])
-    except CalledProcessError:
+    if uncommitted_changes():
         if not error:
             error.append('Cannot %s: Your index contains uncommitted changes.' % (action,))
         else:

--- a/git-imerge
+++ b/git-imerge
@@ -288,6 +288,17 @@ class UncleanWorkTreeError(Failure):
     pass
 
 
+def refresh_index():
+    process = subprocess.Popen(
+        ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+    out, err = communicate(process)
+    retcode = process.poll()
+    if retcode:
+        raise UncleanWorkTreeError(err.rstrip() or out.rstrip())
+
+
 def require_clean_work_tree(action):
     """Verify that the current tree is clean.
 
@@ -303,14 +314,7 @@ def require_clean_work_tree(action):
     if retcode:
         raise UncleanWorkTreeError(err.rstrip())
 
-    process = subprocess.Popen(
-        ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
-    out, err = communicate(process)
-    retcode = process.poll()
-    if retcode:
-        raise UncleanWorkTreeError(err.rstrip() or out.rstrip())
+    refresh_index()
 
     error = []
     try:

--- a/git-imerge
+++ b/git-imerge
@@ -299,6 +299,16 @@ def refresh_index():
         raise UncleanWorkTreeError(err.rstrip() or out.rstrip())
 
 
+def unstaged_changes():
+    """Return True iff there are unstaged changes in the working copy"""
+
+    try:
+        check_call(['git', 'diff-files', '--quiet', '--ignore-submodules'])
+        return False
+    except CalledProcessError:
+        return True
+
+
 def require_clean_work_tree(action):
     """Verify that the current tree is clean.
 
@@ -317,9 +327,7 @@ def require_clean_work_tree(action):
     refresh_index()
 
     error = []
-    try:
-        check_call(['git', 'diff-files', '--quiet', '--ignore-submodules'])
-    except CalledProcessError:
+    if unstaged_changes():
         error.append('Cannot %s: You have unstaged changes.' % (action,))
 
     try:


### PR DESCRIPTION
The old code for the `continue` and `record` commands detected when to make an automatic commit based on there being uncommitted changes in the working copy. But it can be that a merge legitimately results in no changes compared to `HEAD`. So instead, whenever a merge is in progress and all changes are staged, commit the merge and continue.

This change fixes #42, fixes #57, and I think it also fixes #29.

I've lightly tested this change by hand; it would be great if other people would give it a try. Or, like, we could develop actual testing infrastructure :anguished:
