### PR TITLE
Add bash completion for new `drop` and `revert` subcommands

### DIFF
--- a/git-imerge.bashcomplete
+++ b/git-imerge.bashcomplete
@@ -19,6 +19,8 @@ __git_imerge_commands="\
 start
 merge
 rebase
+drop
+revert
 continue
 finish
 diagram
@@ -67,6 +69,13 @@ __git_imerge_merge_options="\
 --manual
 "
 
+__git_imerge_drop_options="\
+--help
+--name
+--branch
+--manual
+"
+
 __git_imerge_list_options="\
 --help
 "
@@ -98,6 +107,8 @@ __git_imerge_diagram_options="\
 __git_imerge_remove_options=$__git_imerge_autofill_options
 
 __git_imerge_rebase_options=$__git_imerge_merge_options
+
+__git_imerge_revert_options=$__git_imerge_drop_options
 
 __git-imerge_start_completion() {
 	case "$1_$cur" in
@@ -177,6 +188,23 @@ __git-imerge_merge_completion() {
 
 __git-imerge_rebase_completion() {
 	__git-imerge_merge_completion $1
+}
+
+__git-imerge_drop_completion() {
+	case "$1_$cur" in
+	--help_|--branch_|_--branch=|--name_|_--name=)
+		return
+		;;
+	*-|*_-*?)
+		__gitcomp "$__git_imerge_merge_options"
+		return
+		;;
+	esac
+	__gitcomp "$(__git_imerge_branches)"
+}
+
+__git-imerge_revert_completion() {
+	__git-imerge_drop_completion $1
 }
 
 __git-imerge_list_completion() {


### PR DESCRIPTION
Cargo-cult the bash completion code for `merge` to support the new `drop` and `revert` subcommands.

@ralfth, would you mind giving this a look? I expect these subcommands mostly to be invoked with recent commits or commit ranges as arguments, in forms like `HEAD^^^`, `HEAD~5`, `1ab2d34`, or dotted pairs like `HEAD~8..HEAD~5` or `54789cc44a33bc8477d513dc5db379eddefd257a..49ac1c208c8ba7a8884c917d16c5124797d8abf9` rather than the names of existing branches. I guess the arguments will often be copy-pasted. So my feeling is that completing on `__git-imerge_branches` won't often help, but probably doesn't hurt either. Any advice or hints would be appreciated!
