### PR TITLE
Ignore compiled Python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*.pyc
+*.pyo
 /*.html


### PR DESCRIPTION
We don't create any such files directly, but they are often a side-effect of working and testing in Python, so make sure they don't get committed accidentally.
