### PR TITLE
Abstract the interaction with the Git repo into a new class, `GitRepository`

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -901,6 +901,9 @@ class GitRepository(object):
 
         self.update_ref('HEAD', 'HEAD^0', msg, deref=False)
 
+    def reset_hard(self, commit):
+        check_call(['git', 'reset', '--hard', commit])
+
     def abort_merge(self):
         # We don't use "git merge --abort" here because it was
         # only added in git version 1.7.4.
@@ -2813,7 +2816,7 @@ class MergeState(Block):
                     )
 
             if head_refname == refname:
-                check_call(['git', 'reset', '--hard', commit])
+                self.git.reset_hard(commit)
             else:
                 self.git.update_ref(
                     refname, commit, 'imerge: recording final merge',

--- a/git-imerge
+++ b/git-imerge
@@ -2486,6 +2486,52 @@ class MergeState(Block):
                         return (i1, i2)
         raise CommitNotFoundError(commit)
 
+    def request_user_merge(self, i1, i2):
+        """Prepare the working tree for the user to do a manual merge.
+
+        It is assumed that the merges above and to the left of (i1, i2)
+        are already done."""
+
+        above = self[i1, i2 - 1]
+        left = self[i1 - 1, i2]
+        if not above.is_known() or not left.is_known():
+            raise RuntimeError('The parents of merge %d-%d are not ready' % (i1, i2))
+        refname = MergeState.get_scratch_refname(self.name)
+        check_call([
+            'git', 'update-ref',
+            '-m', 'imerge %r: Prepare merge %d-%d' % (self.name, i1, i2,),
+            refname, above.sha1,
+            ])
+        checkout(refname)
+        logmsg = 'imerge \'%s\': manual merge %d-%d' % (self.name, i1, i2)
+        try:
+            check_call([
+                'git', 'merge', '--no-commit',
+                '-m', logmsg,
+                left.sha1,
+                ])
+        except CalledProcessError:
+            # We expect an error (otherwise we would have automerged!)
+            pass
+        sys.stderr.write(
+            '\n'
+            'Original first commit:\n'
+            )
+        check_call(['git', '--no-pager', 'log', '--no-walk', self[i1, 0].sha1])
+        sys.stderr.write(
+            '\n'
+            'Original second commit:\n'
+            )
+        check_call(['git', '--no-pager', 'log', '--no-walk', self[0, i2].sha1])
+        sys.stderr.write(
+            '\n'
+            'There was a conflict merging commit %d-%d, shown above.\n'
+            'Please resolve the conflict, commit the result, then type\n'
+            '\n'
+            '    git-imerge continue\n'
+            % (i1, i2)
+            )
+
     def incorporate_manual_merge(self, commit):
         """Record commit as a manual merge of its parents.
 
@@ -2868,53 +2914,6 @@ class MergeState(Block):
             )
 
 
-def request_user_merge(merge_state, i1, i2):
-    """Prepare the working tree for the user to do a manual merge.
-
-    It is assumed that the merges above and to the left of (i1, i2)
-    are already done."""
-
-    above = merge_state[i1, i2 - 1]
-    left = merge_state[i1 - 1, i2]
-    if not above.is_known() or not left.is_known():
-        raise RuntimeError('The parents of merge %d-%d are not ready' % (i1, i2))
-    refname = MergeState.get_scratch_refname(merge_state.name)
-    check_call([
-        'git', 'update-ref',
-        '-m', 'imerge %r: Prepare merge %d-%d' % (merge_state.name, i1, i2,),
-        refname, above.sha1,
-        ])
-    checkout(refname)
-    logmsg = 'imerge \'%s\': manual merge %d-%d' % (merge_state.name, i1, i2)
-    try:
-        check_call([
-            'git', 'merge', '--no-commit',
-            '-m', logmsg,
-            left.sha1,
-            ])
-    except CalledProcessError:
-        # We expect an error (otherwise we would have automerged!)
-        pass
-    sys.stderr.write(
-        '\n'
-        'Original first commit:\n'
-        )
-    check_call(['git', '--no-pager', 'log', '--no-walk', merge_state[i1, 0].sha1])
-    sys.stderr.write(
-        '\n'
-        'Original second commit:\n'
-        )
-    check_call(['git', '--no-pager', 'log', '--no-walk', merge_state[0, i2].sha1])
-    sys.stderr.write(
-        '\n'
-        'There was a conflict merging commit %d-%d, shown above.\n'
-        'Please resolve the conflict, commit the result, then type\n'
-        '\n'
-        '    git-imerge continue\n'
-        % (i1, i2)
-        )
-
-
 def simple_merge_in_progress():
     # Check if a merge (of a single branch) is in progress:
     try:
@@ -3091,7 +3090,7 @@ def cmd_start(parser, options):
     try:
         merge_state.auto_complete_frontier()
     except FrontierBlockedError as e:
-        request_user_merge(merge_state, e.i1, e.i2)
+        merge_state.request_user_merge(e.i1, e.i2)
     else:
         sys.stderr.write('Merge is complete!\n')
 
@@ -3159,7 +3158,7 @@ def cmd_merge(parser, options):
     try:
         merge_state.auto_complete_frontier()
     except FrontierBlockedError as e:
-        request_user_merge(merge_state, e.i1, e.i2)
+        merge_state.request_user_merge(e.i1, e.i2)
     else:
         sys.stderr.write('Merge is complete!\n')
 
@@ -3230,7 +3229,7 @@ def cmd_rebase(parser, options):
     try:
         merge_state.auto_complete_frontier()
     except FrontierBlockedError as e:
-        request_user_merge(merge_state, e.i1, e.i2)
+        merge_state.request_user_merge(e.i1, e.i2)
     else:
         sys.stderr.write('Merge is complete!\n')
 
@@ -3353,7 +3352,7 @@ def cmd_drop(parser, options):
     try:
         merge_state.auto_complete_frontier()
     except FrontierBlockedError as e:
-        request_user_merge(merge_state, e.i1, e.i2)
+        merge_state.request_user_merge(e.i1, e.i2)
     else:
         sys.stderr.write('Merge is complete!\n')
 
@@ -3471,7 +3470,7 @@ def cmd_revert(parser, options):
     try:
         merge_state.auto_complete_frontier()
     except FrontierBlockedError as e:
-        request_user_merge(merge_state, e.i1, e.i2)
+        merge_state.request_user_merge(e.i1, e.i2)
     else:
         sys.stderr.write('Merge is complete!\n')
 
@@ -3498,7 +3497,7 @@ def cmd_continue(parser, options):
     try:
         merge_state.auto_complete_frontier()
     except FrontierBlockedError as e:
-        request_user_merge(merge_state, e.i1, e.i2)
+        merge_state.request_user_merge(e.i1, e.i2)
     else:
         sys.stderr.write('Merge is complete!\n')
 

--- a/git-imerge
+++ b/git-imerge
@@ -353,6 +353,15 @@ class GitRepository(object):
         except CalledProcessError:
             return False
 
+    def unstaged_changes(self):
+        """Return True iff there are unstaged changes in the working copy"""
+
+        try:
+            check_call(['git', 'diff-files', '--quiet', '--ignore-submodules'])
+            return False
+        except CalledProcessError:
+            return True
+
     def refresh_index(self):
         process = subprocess.Popen(
             ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
@@ -474,7 +483,7 @@ class GitRepository(object):
         self.refresh_index()
 
         error = []
-        if unstaged_changes():
+        if self.unstaged_changes():
             error.append('Cannot %s: You have unstaged changes.' % (action,))
 
         if uncommitted_changes():
@@ -512,7 +521,7 @@ class GitRepository(object):
         # Check if all conflicts are resolved and everything in the
         # working tree is staged:
         self.refresh_index()
-        if unstaged_changes():
+        if self.unstaged_changes():
             raise UncleanWorkTreeError(
                 'Cannot proceed: You have unstaged changes.'
                 )
@@ -581,16 +590,6 @@ class GitRepository(object):
 
         [commit] = parents
         return commit
-
-
-def unstaged_changes():
-    """Return True iff there are unstaged changes in the working copy"""
-
-    try:
-        check_call(['git', 'diff-files', '--quiet', '--ignore-submodules'])
-        return False
-    except CalledProcessError:
-        return True
 
 
 def uncommitted_changes():

--- a/git-imerge
+++ b/git-imerge
@@ -347,6 +347,19 @@ class GitRepository(object):
             )
         return json.loads(state_string)
 
+    def is_ancestor(self, commit1, commit2):
+        """Return True iff commit1 is an ancestor (or equal to) commit2."""
+
+        if commit1 == commit2:
+            return True
+        else:
+            return int(
+                check_output([
+                    'git', 'rev-list', '--count', '--ancestry-path',
+                    '%s..%s' % (commit1, commit2,),
+                    ]).strip()
+                ) != 0
+
     def is_ff(self, refname, commit):
         """Would updating refname to commit be a fast-forward update?
 
@@ -361,7 +374,7 @@ class GitRepository(object):
             # refname doesn't already exist; no problem.
             return True
         else:
-            return MergeState._is_ancestor(ref_oldval, commit)
+            return self.is_ancestor(ref_oldval, commit)
 
 
 def get_default_edit():
@@ -2511,20 +2524,6 @@ class MergeState(Block):
         self[i1, i2].record_merge(commit, MergeRecord.NEW_MANUAL)
         return (i1, i2)
 
-    @staticmethod
-    def _is_ancestor(commit1, commit2):
-        """Return True iff commit1 is an ancestor (or equal to) commit2."""
-
-        if commit1 == commit2:
-            return True
-        else:
-            return int(
-                check_output([
-                    'git', 'rev-list', '--count', '--ancestry-path',
-                    '%s..%s' % (commit1, commit2,),
-                    ]).strip()
-                ) != 0
-
     def _set_refname(self, refname, commit, force=False):
         try:
             ref_oldval = get_commit_sha1(refname)
@@ -2542,7 +2541,7 @@ class MergeState(Block):
                 head_refname = None
 
             if not force:
-                if not MergeState._is_ancestor(ref_oldval, commit):
+                if not self.git.is_ancestor(ref_oldval, commit):
                     raise Failure(
                         '%s cannot be fast-forwarded to %s!' % (refname, commit)
                         )

--- a/git-imerge
+++ b/git-imerge
@@ -321,7 +321,15 @@ class GitRepository(object):
         )
 
     def __init__(self):
-        pass
+        self.git_dir_cache = None
+
+    def git_dir(self):
+        if self.git_dir_cache is None:
+            self.git_dir_cache = check_output(
+                ['git', 'rev-parse', '--git-dir']
+                ).rstrip('\n')
+
+        return self.git_dir_cache
 
     def check_imerge_name_format(self, name):
         """Check that name is a valid imerge name."""
@@ -569,7 +577,7 @@ class GitRepository(object):
         """Return True iff a merge (of a single branch) is in progress."""
 
         try:
-            with open(os.path.join(git_dir(), 'MERGE_HEAD')) as f:
+            with open(os.path.join(self.git_dir(), 'MERGE_HEAD')) as f:
                 heads = [line.rstrip() for line in f]
         except IOError:
             return False
@@ -781,18 +789,6 @@ def rev_list_with_parents(*args):
     for line in check_output(cmd).splitlines():
         commits = line.strip().split()
         yield (commits[0], commits[1:])
-
-
-git_dir_cache = None
-
-def git_dir():
-    global git_dir_cache
-
-    if git_dir_cache is None:
-        git_dir_cache = check_output(
-            ['git', 'rev-parse', '--git-dir']
-            ).rstrip('\n')
-    return git_dir_cache
 
 
 BRANCH_PREFIX = 'refs/heads/'

--- a/git-imerge
+++ b/git-imerge
@@ -335,7 +335,7 @@ class GitRepository(object):
         for line in check_output(['git', 'for-each-ref', state_refname]).splitlines():
             (sha1, type, refname) = line.split()
             if refname == state_refname and type == 'blob':
-                MergeState._read_state(name, sha1)
+                MergeState._read_state(name)
                 # If that didn't throw an exception:
                 return True
         else:
@@ -2125,8 +2125,10 @@ class MergeState(Block):
         return 'refs/heads/imerge/%s' % (name,)
 
     @staticmethod
-    def _read_state(name, sha1):
-        state_string = check_output(['git', 'cat-file', 'blob', sha1])
+    def _read_state(name):
+        state_string = check_output(
+            ['git', 'cat-file', 'blob', 'refs/imerge/%s/state' % (name,)],
+            )
         state = json.loads(state_string)
 
         version = tuple(int(i) for i in state['version'].split('.'))
@@ -2237,7 +2239,7 @@ class MergeState(Block):
             if m:
                 if type != 'blob':
                     raise Failure('Reference %r is not a blob!' % (refname,))
-                state = MergeState._read_state(name, sha1)
+                state = MergeState._read_state(name)
                 continue
 
             unexpected.append(refname)

--- a/git-imerge
+++ b/git-imerge
@@ -309,6 +309,8 @@ class GitTemporaryHead(object):
 
 
 class GitRepository(object):
+    BRANCH_PREFIX = 'refs/heads/'
+
     MERGE_STATE_REFNAME_RE = re.compile(
         r"""
         ^
@@ -809,6 +811,17 @@ class GitRepository(object):
 
         return (merge_base, commits1, commits2)
 
+    def checkout(self, refname, quiet=False):
+        cmd = ['git', 'checkout']
+        if quiet:
+            cmd += ['--quiet']
+        if refname.startswith(GitRepository.BRANCH_PREFIX):
+            target = refname[len(GitRepository.BRANCH_PREFIX):]
+        else:
+            target = '%s^0' % (refname,)
+        cmd += [target]
+        check_call(cmd)
+
     def commit_tree(self, tree, parents, msg, metadata=None):
         """Create a commit containing the specified tree.
 
@@ -850,21 +863,6 @@ class GitRepository(object):
         """
 
         return GitTemporaryHead(self, message)
-
-
-BRANCH_PREFIX = 'refs/heads/'
-
-
-def checkout(refname, quiet=False):
-    cmd = ['git', 'checkout']
-    if quiet:
-        cmd += ['--quiet']
-    if refname.startswith(BRANCH_PREFIX):
-        target = refname[len(BRANCH_PREFIX):]
-    else:
-        target = '%s^0' % (refname,)
-    cmd += [target]
-    check_call(cmd)
 
 
 class NotFirstParentAncestorError(Failure):
@@ -2558,7 +2556,7 @@ class MergeState(Block):
             '-m', 'imerge %r: Prepare merge %d-%d' % (self.name, i1, i2,),
             refname, above.sha1,
             ])
-        checkout(refname)
+        self.git.checkout(refname)
         logmsg = 'imerge \'%s\': manual merge %d-%d' % (self.name, i1, i2)
         try:
             check_call([
@@ -2740,7 +2738,7 @@ class MergeState(Block):
         except ValueError:
             # refname doesn't already exist; simply point it at commit:
             check_call(['git', 'update-ref', refname, commit])
-            checkout(refname, quiet=True)
+            self.git.checkout(refname, quiet=True)
         else:
             # refname already exists.  This has two ramifications:
             # 1. HEAD might point at it
@@ -2764,7 +2762,7 @@ class MergeState(Block):
                     '-m', 'imerge: recording final merge',
                     refname, commit,
                     ])
-                checkout(refname, quiet=True)
+                self.git.checkout(refname, quiet=True)
 
     def simplify_to_full(self, refname, force=False):
         for i1 in range(1, self.len1):
@@ -3306,7 +3304,7 @@ def cmd_drop(parser, options):
     # Create a branch based on end that contains the inverse of the
     # commits that we want to drop. This will be tip2:
 
-    checkout(end)
+    git.checkout(end)
     for commit in reversed(to_drop):
         cmd = ['git', 'revert', '--no-edit']
         if len(git.get_commit_parents(commit)) > 1:
@@ -3424,7 +3422,7 @@ def cmd_revert(parser, options):
     # Create a branch based on end that contains the inverse of the
     # commits that we want to drop. This will be tip2:
 
-    checkout(end)
+    git.checkout(end)
     for commit in reversed(to_revert):
         cmd = ['git', 'revert', '--no-edit']
         if len(git.get_commit_parents(commit)) > 1:

--- a/git-imerge
+++ b/git-imerge
@@ -330,6 +330,29 @@ class GitRepository(object):
         except CalledProcessError:
             return None
 
+    def get_default_edit(self):
+        """Should '--edit' be used when committing intermediate user merges?
+
+        When 'git imerge continue' or 'git imerge record' finds a user
+        merge that can be committed, should it (by default) ask the user
+        to edit the commit message? This behavior can be configured via
+        'imerge.editmergemessages'. If it is not configured, return False.
+
+        Please note that this function is only used to choose the default
+        value. It can be overridden on the command line using '--edit' or
+        '--no-edit'.
+
+        """
+
+        try:
+            return {'true' : True, 'false' : False}[
+                check_output(
+                    ['git', 'config', '--bool', 'imerge.editmergemessages']
+                    ).rstrip()
+                ]
+        except CalledProcessError:
+            return False
+
     def check_imerge_exists(self, name):
         """Verify that a MergeState with the given name exists.
 
@@ -442,7 +465,7 @@ class GitRepository(object):
         cmd = ['git', 'commit', '--no-verify']
 
         if edit_log_msg is None:
-            edit_log_msg = get_default_edit()
+            edit_log_msg = self.get_default_edit()
 
         if edit_log_msg:
             cmd += ['--edit']
@@ -455,30 +478,6 @@ class GitRepository(object):
             raise Failure('Could not commit staged changes.')
 
         return True
-
-
-def get_default_edit():
-    """Should '--edit' be used when committing intermediate user merges?
-
-    When 'git imerge continue' or 'git imerge record' finds a user
-    merge that can be committed, should it (by default) ask the user
-    to edit the commit message? This behavior can be configured via
-    'imerge.editmergemessages'. If it is not configured, return False.
-
-    Please note that this function is only used to choose the default
-    value. It can be overridden on the command line using '--edit' or
-    '--no-edit'.
-
-    """
-
-    try:
-        return {'true' : True, 'false' : False}[
-            check_output(
-                ['git', 'config', '--bool', 'imerge.editmergemessages']
-                ).rstrip()
-            ]
-    except CalledProcessError:
-        return False
 
 
 def refresh_index():

--- a/git-imerge
+++ b/git-imerge
@@ -335,7 +335,7 @@ class GitRepository(object):
         for line in check_output(['git', 'for-each-ref', state_refname]).splitlines():
             (sha1, type, refname) = line.split()
             if refname == state_refname and type == 'blob':
-                MergeState._read_state(name)
+                MergeState._read_state(self, name)
                 # If that didn't throw an exception:
                 return True
         else:
@@ -2125,7 +2125,7 @@ class MergeState(Block):
         return 'refs/heads/imerge/%s' % (name,)
 
     @staticmethod
-    def _read_state(name):
+    def _read_state(git, name):
         state_string = check_output(
             ['git', 'cat-file', 'blob', 'refs/imerge/%s/state' % (name,)],
             )
@@ -2239,7 +2239,7 @@ class MergeState(Block):
             if m:
                 if type != 'blob':
                     raise Failure('Reference %r is not a blob!' % (refname,))
-                state = MergeState._read_state(name)
+                state = MergeState._read_state(git, name)
                 continue
 
             unexpected.append(refname)

--- a/git-imerge
+++ b/git-imerge
@@ -661,6 +661,11 @@ class GitRepository(object):
         else:
             return self.get_commit_sha1('HEAD')
 
+    def manualmerge(self, commit, msg):
+        """Initiate a merge of commit into the current HEAD."""
+
+        check_call(['git', 'merge', '--no-commit', '-m', msg, commit,])
+
     def require_clean_work_tree(self, action):
         """Verify that the current tree is clean.
 
@@ -2631,11 +2636,7 @@ class MergeState(Block):
         self.git.checkout(refname)
         logmsg = 'imerge \'%s\': manual merge %d-%d' % (self.name, i1, i2)
         try:
-            check_call([
-                'git', 'merge', '--no-commit',
-                '-m', logmsg,
-                left.sha1,
-                ])
+            self.git.manualmerge(left.sha1, logmsg)
         except CalledProcessError:
             # We expect an error (otherwise we would have automerged!)
             pass

--- a/git-imerge
+++ b/git-imerge
@@ -362,6 +362,18 @@ class GitRepository(object):
         except CalledProcessError:
             return True
 
+    def uncommitted_changes(self):
+        """Return True iff the index contains uncommitted changes."""
+
+        try:
+            check_call([
+                'git', 'diff-index', '--cached', '--quiet',
+                '--ignore-submodules', 'HEAD', '--',
+                ])
+            return False
+        except CalledProcessError:
+            return True
+
     def refresh_index(self):
         process = subprocess.Popen(
             ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
@@ -486,7 +498,7 @@ class GitRepository(object):
         if self.unstaged_changes():
             error.append('Cannot %s: You have unstaged changes.' % (action,))
 
-        if uncommitted_changes():
+        if self.uncommitted_changes():
             if not error:
                 error.append('Cannot %s: Your index contains uncommitted changes.' % (action,))
             else:
@@ -590,19 +602,6 @@ class GitRepository(object):
 
         [commit] = parents
         return commit
-
-
-def uncommitted_changes():
-    """Return True iff the index contains uncommitted changes."""
-
-    try:
-        check_call([
-            'git', 'diff-index', '--cached', '--quiet',
-            '--ignore-submodules', 'HEAD', '--',
-            ])
-        return False
-    except CalledProcessError:
-        return True
 
 
 class InvalidBranchNameError(Failure):

--- a/git-imerge
+++ b/git-imerge
@@ -277,6 +277,16 @@ class GitRepository(object):
     def __init__(self):
         pass
 
+    def check_imerge_name_format(self, name):
+        """Check that name is a valid imerge name."""
+
+        try:
+            call_silently(
+                ['git', 'check-ref-format', 'refs/imerge/%s' % (name,)]
+                )
+        except CalledProcessError:
+            raise Failure('Name %r is not a valid refname component!' % (name,))
+
     def iter_existing_imerge_names(self):
         """Iterate over the names of existing MergeStates in this repo."""
 
@@ -2150,17 +2160,6 @@ class MergeState(Block):
                 )
 
     @staticmethod
-    def check_name_format(name):
-        """Check that name is a valid imerge name."""
-
-        try:
-            call_silently(
-                ['git', 'check-ref-format', 'refs/imerge/%s' % (name,)]
-                )
-        except CalledProcessError:
-            raise Failure('Name %r is not a valid refname component!' % (name,))
-
-    @staticmethod
     def initialize(
             git, name, merge_base,
             tip1, commits1,
@@ -2170,7 +2169,7 @@ class MergeState(Block):
             ):
         """Create and return a new MergeState object."""
 
-        MergeState.check_name_format(name)
+        git.check_imerge_name_format(name)
         if branch:
             check_branch_name_format(branch)
         else:
@@ -3110,7 +3109,7 @@ def cmd_merge(parser, options):
     else:
         # By default, name the imerge after the branch being merged:
         name = tip2
-        MergeState.check_name_format(name)
+        git.check_imerge_name_format(name)
 
     try:
         tip1 = check_output(

--- a/git-imerge
+++ b/git-imerge
@@ -661,6 +661,25 @@ class GitRepository(object):
         [commit] = parents
         return commit
 
+    def get_boundaries(self, tip1, tip2, first_parent):
+        """Get the boundaries of an incremental merge.
+
+        Given the tips of two branches that should be merged, return
+        (merge_base, commits1, commits2) describing the edges of the
+        imerge.  Raise Failure if there are any problems."""
+
+        merge_base = compute_best_merge_base(tip1, tip2)
+
+        commits1 = linear_ancestry(merge_base, tip1, first_parent)
+        if not commits1:
+            raise NothingToDoError(tip1, tip2)
+
+        commits2 = linear_ancestry(merge_base, tip2, first_parent)
+        if not commits2:
+            raise NothingToDoError(tip2, tip1)
+
+        return (merge_base, commits1, commits2)
+
     def temporary_head(self, message):
         """Return a context manager to manage a temporary HEAD.
 
@@ -912,26 +931,6 @@ def compute_best_merge_base(tip1, tip2):
             best_count = count
 
     return best_base
-
-
-def get_boundaries(tip1, tip2, first_parent):
-    """Get the boundaries of an incremental merge.
-
-    Given the tips of two branches that should be merged, return
-    (merge_base, commits1, commits2) describing the edges of the
-    imerge.  Raise Failure if there are any problems."""
-
-    merge_base = compute_best_merge_base(tip1, tip2)
-
-    commits1 = linear_ancestry(merge_base, tip1, first_parent)
-    if not commits1:
-        raise NothingToDoError(tip1, tip2)
-
-    commits2 = linear_ancestry(merge_base, tip2, first_parent)
-    if not commits2:
-        raise NothingToDoError(tip2, tip1)
-
-    return (merge_base, commits1, commits2)
 
 
 def reparent(commit, parent_sha1s, msg=None):
@@ -3036,7 +3035,7 @@ def cmd_init(parser, options):
         tip1 = 'HEAD'
     tip2 = options.tip2
     try:
-        (merge_base, commits1, commits2) = get_boundaries(
+        (merge_base, commits1, commits2) = git.get_boundaries(
             tip1, tip2, options.first_parent,
             )
     except NonlinearAncestryError as e:
@@ -3073,7 +3072,7 @@ def cmd_start(parser, options):
     tip2 = options.tip2
 
     try:
-        (merge_base, commits1, commits2) = get_boundaries(
+        (merge_base, commits1, commits2) = git.get_boundaries(
             tip1, tip2, options.first_parent,
             )
     except NonlinearAncestryError as e:
@@ -3138,7 +3137,7 @@ def cmd_merge(parser, options):
                 )
 
     try:
-        (merge_base, commits1, commits2) = get_boundaries(
+        (merge_base, commits1, commits2) = git.get_boundaries(
             tip1, tip2, options.first_parent,
             )
     except NonlinearAncestryError as e:
@@ -3209,7 +3208,7 @@ def cmd_rebase(parser, options):
                 )
 
     try:
-        (merge_base, commits1, commits2) = get_boundaries(
+        (merge_base, commits1, commits2) = git.get_boundaries(
             tip1, tip2, options.first_parent,
             )
     except NonlinearAncestryError as e:
@@ -3331,7 +3330,7 @@ def cmd_drop(parser, options):
     tip2 = rev_parse('HEAD')
 
     try:
-        (merge_base, commits1, commits2) = get_boundaries(
+        (merge_base, commits1, commits2) = git.get_boundaries(
             tip1, tip2, options.first_parent,
             )
     except NonlinearAncestryError as e:
@@ -3449,7 +3448,7 @@ def cmd_revert(parser, options):
     tip2 = rev_parse('HEAD')
 
     try:
-        (merge_base, commits1, commits2) = get_boundaries(
+        (merge_base, commits1, commits2) = git.get_boundaries(
             tip1, tip2, options.first_parent,
             )
     except NonlinearAncestryError as e:

--- a/git-imerge
+++ b/git-imerge
@@ -2526,8 +2526,7 @@ class MergeState(Block):
                     ]).strip()
                 ) != 0
 
-    @staticmethod
-    def _set_refname(refname, commit, force=False):
+    def _set_refname(self, refname, commit, force=False):
         try:
             ref_oldval = get_commit_sha1(refname)
         except ValueError:

--- a/git-imerge
+++ b/git-imerge
@@ -862,6 +862,11 @@ class GitRepository(object):
 
         check_call(['git', 'update-ref'] + opt + ['-m', msg, '-d', refname])
 
+    def detach(self, msg):
+        """Detach HEAD. msg is used for the reflog."""
+
+        self.update_ref('HEAD', 'HEAD^0', msg, deref=False)
+
     def compute_best_merge_base(self, tip1, tip2):
         try:
             merge_bases = check_output(['git', 'merge-base', '--all', tip1, tip2]).splitlines()
@@ -2464,11 +2469,7 @@ class MergeState(Block):
             except CalledProcessError:
                 pass
             # Detach head so that we can delete scratch_refname:
-            git.update_ref(
-                'HEAD', 'HEAD^0',
-                'Detach HEAD from %s' % (scratch_refname,),
-                deref=False,
-                )
+            git.detach('Detach HEAD from %s' % (scratch_refname,))
 
         # Delete the scratch refname:
         git.delete_ref(
@@ -2751,9 +2752,7 @@ class MergeState(Block):
         (i1, i2) = self.incorporate_manual_merge(commit)
 
         # Now detach head so that we can delete refname.
-        self.git.update_ref(
-            'HEAD', commit, 'Detach HEAD from %s' % (refname,), deref=False,
-            )
+        self.git.detach('Detach HEAD from %s' % (refname,))
 
         self.git.delete_ref(
             refname, 'imerge %s: remove scratch reference' % (self.name,),

--- a/git-imerge
+++ b/git-imerge
@@ -479,6 +479,11 @@ class GitRepository(object):
         if retcode:
             raise UncleanWorkTreeError(err.rstrip() or out.rstrip())
 
+    def verify_imerge_name_available(self, name):
+        self.check_imerge_name_format(name)
+        if check_output(['git', 'for-each-ref', 'refs/imerge/%s' % (name,)]):
+            raise Failure('Name %r is already in use!' % (name,))
+
     def check_imerge_exists(self, name):
         """Verify that a MergeState with the given name exists.
 
@@ -2247,14 +2252,11 @@ class MergeState(Block):
             ):
         """Create and return a new MergeState object."""
 
-        git.check_imerge_name_format(name)
+        git.verify_imerge_name_available(name)
         if branch:
             git.check_branch_name_format(branch)
         else:
             branch = name
-
-        if check_output(['git', 'for-each-ref', 'refs/imerge/%s' % (name,)]):
-            raise Failure('Name %r is already in use!' % (name,))
 
         if goal == 'rebase':
             MergeState._check_no_merges(git, commits2)

--- a/git-imerge
+++ b/git-imerge
@@ -378,6 +378,23 @@ class GitRepository(object):
             )
         return json.loads(state_string)
 
+    def write_imerge_state_dict(self, name, state):
+        state_string = json.dumps(state, sort_keys=True) + '\n'
+
+        cmd = ['git', 'hash-object', '-t', 'blob', '-w', '--stdin']
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        out = communicate(p, input=state_string)[0]
+        retcode = p.poll()
+        if retcode:
+            raise CalledProcessError(retcode, cmd)
+        sha1 = out.strip()
+        check_call([
+            'git', 'update-ref',
+            '-m', 'imerge %r: Record state' % (name,),
+            'refs/imerge/%s/state' % (name,),
+            sha1,
+            ])
+
     def is_ancestor(self, commit1, commit2):
         """Return True iff commit1 is an ancestor (or equal to) commit2."""
 
@@ -2940,21 +2957,7 @@ class MergeState(Block):
             manual=self.manual,
             branch=self.branch,
             )
-        state_string = json.dumps(state, sort_keys=True) + '\n'
-
-        cmd = ['git', 'hash-object', '-t', 'blob', '-w', '--stdin']
-        p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        out = communicate(p, input=state_string)[0]
-        retcode = p.poll()
-        if retcode:
-            raise CalledProcessError(retcode, cmd)
-        sha1 = out.strip()
-        check_call([
-            'git', 'update-ref',
-            '-m', 'imerge %r: Record state' % (self.name,),
-            'refs/imerge/%s/state' % (self.name,),
-            sha1,
-            ])
+        self.git.write_imerge_state_dict(self.name, state)
 
     def __str__(self):
         return 'MergeState(\'%s\', tip1=\'%s\', tip2=\'%s\', goal=\'%s\')' % (

--- a/git-imerge
+++ b/git-imerge
@@ -406,6 +406,17 @@ class GitRepository(object):
         else:
             return get_commit_sha1('HEAD')
 
+    def simple_merge_in_progress(self):
+        """Return True iff a merge (of a single branch) is in progress."""
+
+        try:
+            with open(os.path.join(git_dir(), 'MERGE_HEAD')) as f:
+                heads = [line.rstrip() for line in f]
+        except IOError:
+            return False
+
+        return len(heads) == 1
+
     def commit_user_merge(self, edit_log_msg=None):
         """If a merge is in progress and ready to be committed, commit it.
 
@@ -415,7 +426,7 @@ class GitRepository(object):
 
         """
 
-        if not simple_merge_in_progress():
+        if not self.simple_merge_in_progress():
             return False
 
         # Check if all conflicts are resolved and everything in the
@@ -2951,17 +2962,6 @@ class MergeState(Block):
         return 'MergeState(\'%s\', tip1=\'%s\', tip2=\'%s\', goal=\'%s\')' % (
             self.name, self.tip1, self.tip2, self.goal,
             )
-
-
-def simple_merge_in_progress():
-    # Check if a merge (of a single branch) is in progress:
-    try:
-        with open(os.path.join(git_dir(), 'MERGE_HEAD')) as f:
-            heads = [line.rstrip() for line in f]
-    except IOError:
-        return False
-
-    return len(heads) == 1
 
 
 def choose_merge_name(git, name, default_to_unique=True):

--- a/git-imerge
+++ b/git-imerge
@@ -755,6 +755,22 @@ class GitRepository(object):
     def get_tree(self, arg):
         return self.rev_parse('%s^{tree}' % (arg,))
 
+    def update_ref(self, refname, value, msg, deref=True):
+        if deref:
+            opt = []
+        else:
+            opt = ['--no-deref']
+
+        check_call(['git', 'update-ref'] + opt + ['-m', msg, refname, value])
+
+    def delete_ref(self, refname, msg, deref=True):
+        if deref:
+            opt = []
+        else:
+            opt = ['--no-deref']
+
+        check_call(['git', 'update-ref'] + opt + ['-m', msg, '-d', refname])
+
     def compute_best_merge_base(self, tip1, tip2):
         try:
             merge_bases = check_output(['git', 'merge-base', '--all', tip1, tip2]).splitlines()
@@ -1061,19 +1077,17 @@ class MergeRecord(object):
         """If this record has changed, save it."""
 
         def set_ref(source):
-            check_call([
-                'git', 'update-ref',
-                '-m', 'imerge %r: Record %s merge' % (name, source,),
+            git.update_ref(
                 'refs/imerge/%s/%s/%d-%d' % (name, source, i1, i2),
                 self.sha1,
-                ])
+                'imerge %r: Record %s merge' % (name, source,),
+                )
 
         def clear_ref(source):
-            check_call([
-                'git', 'update-ref',
-                '-m', 'imerge %r: Remove obsolete %s merge' % (name, source,),
-                '-d', 'refs/imerge/%s/%s/%d-%d' % (name, source, i1, i2),
-                ])
+            git.delete_ref(
+                'refs/imerge/%s/%s/%d-%d' % (name, source, i1, i2),
+                'imerge %r: Remove obsolete %s merge' % (name, source,),
+                )
 
         if self.flags & self.MANUAL:
             if self.flags & self.AUTO:
@@ -2408,18 +2422,16 @@ class MergeState(Block):
             except CalledProcessError:
                 pass
             # Detach head so that we can delete scratch_refname:
-            check_call([
-                'git', 'update-ref', '--no-deref',
-                '-m', 'Detach HEAD from %s' % (scratch_refname,),
-                'HEAD', git.get_commit_sha1('HEAD'),
-                ])
+            git.update_ref(
+                'HEAD', 'HEAD^0',
+                'Detach HEAD from %s' % (scratch_refname,),
+                deref=False,
+                )
 
         # Delete the scratch refname:
-        check_call([
-            'git', 'update-ref',
-            '-m', 'imerge %s: remove scratch reference' % (name,),
-            '-d', scratch_refname,
-            ])
+        git.delete_ref(
+            scratch_refname, 'imerge %s: remove scratch reference' % (name,),
+            )
 
         # Remove any references referring to intermediate merges:
         for line in check_output([
@@ -2427,11 +2439,7 @@ class MergeState(Block):
                 ]).splitlines():
             (sha1, type, refname) = line.split()
             try:
-                check_call([
-                    'git', 'update-ref',
-                    '-m', 'imerge: remove merge %r' % (name,),
-                    '-d', refname,
-                    ])
+                git.delete_ref(refname, 'imerge: remove merge %r' % (name,))
             except CalledProcessError as e:
                 sys.stderr.write(
                     'Warning: error removing reference %r: %s' % (refname, e)
@@ -2551,11 +2559,10 @@ class MergeState(Block):
         if not above.is_known() or not left.is_known():
             raise RuntimeError('The parents of merge %d-%d are not ready' % (i1, i2))
         refname = MergeState.get_scratch_refname(self.name)
-        check_call([
-            'git', 'update-ref',
-            '-m', 'imerge %r: Prepare merge %d-%d' % (self.name, i1, i2,),
+        self.git.update_ref(
             refname, above.sha1,
-            ])
+            'imerge %r: Prepare merge %d-%d' % (self.name, i1, i2,),
+            )
         self.git.checkout(refname)
         logmsg = 'imerge \'%s\': manual merge %d-%d' % (self.name, i1, i2)
         try:
@@ -2678,13 +2685,10 @@ class MergeState(Block):
             else:
                 # It points to a commit that is already recorded.  We can
                 # delete it without losing any information.
-                check_call([
-                    'git', 'update-ref',
-                    '-m',
-                    'imerge %r: Remove obsolete scratch reference'
-                    % (self.name,),
-                    '-d', refname,
-                    ])
+                self.git.delete_ref(
+                    refname,
+                    'imerge %r: Remove obsolete scratch reference' % (self.name,),
+                    )
                 sys.stderr.write(
                     '%s did not point to a new merge; it has been deleted.\n'
                     % (refname,)
@@ -2707,17 +2711,13 @@ class MergeState(Block):
         (i1, i2) = self.incorporate_manual_merge(commit)
 
         # Now detach head so that we can delete refname.
-        check_call([
-            'git', 'update-ref', '--no-deref',
-            '-m', 'Detach HEAD from %s' % (refname,),
-            'HEAD', commit,
-            ])
+        self.git.update_ref(
+            'HEAD', commit, 'Detach HEAD from %s' % (refname,), deref=False,
+            )
 
-        check_call([
-            'git', 'update-ref',
-            '-m', 'imerge %s: remove scratch reference' % (self.name,),
-            '-d', refname,
-            ])
+        self.git.delete_ref(
+            refname, 'imerge %s: remove scratch reference' % (self.name,),
+            )
 
         try:
             # This might throw NotABlockingCommitError:
@@ -2737,7 +2737,7 @@ class MergeState(Block):
             ref_oldval = self.git.get_commit_sha1(refname)
         except ValueError:
             # refname doesn't already exist; simply point it at commit:
-            check_call(['git', 'update-ref', refname, commit])
+            self.git.update_ref(refname, commit, 'imerge: recording final merge')
             self.git.checkout(refname, quiet=True)
         else:
             # refname already exists.  This has two ramifications:
@@ -2757,11 +2757,9 @@ class MergeState(Block):
             if head_refname == refname:
                 check_call(['git', 'reset', '--hard', commit])
             else:
-                check_call([
-                    'git', 'update-ref',
-                    '-m', 'imerge: recording final merge',
-                    refname, commit,
-                    ])
+                self.git.update_ref(
+                    refname, commit, 'imerge: recording final merge',
+                    )
                 self.git.checkout(refname, quiet=True)
 
     def simplify_to_full(self, refname, force=False):

--- a/git-imerge
+++ b/git-imerge
@@ -370,6 +370,16 @@ class GitRepository(object):
         except CalledProcessError:
             raise Failure('Name %r is not a valid refname component!' % (name,))
 
+    def check_branch_name_format(self, name):
+        """Check that name is a valid branch name."""
+
+        try:
+            call_silently(
+                ['git', 'check-ref-format', 'refs/heads/%s' % (name,)]
+                )
+        except CalledProcessError:
+            raise InvalidBranchNameError('Name %r is not a valid branch name!' % (name,))
+
     def iter_existing_imerge_names(self):
         """Iterate over the names of existing MergeStates in this repo."""
 
@@ -448,16 +458,6 @@ class GitRepository(object):
             return False
         except CalledProcessError:
             return True
-
-    def check_branch_name_format(self, name):
-        """Check that name is a valid branch name."""
-
-        try:
-            call_silently(
-                ['git', 'check-ref-format', 'refs/heads/%s' % (name,)]
-                )
-        except CalledProcessError:
-            raise InvalidBranchNameError('Name %r is not a valid branch name!' % (name,))
 
     def get_commit_sha1(self, arg):
         """Convert arg into a SHA1 and verify that it refers to a commit.

--- a/git-imerge
+++ b/git-imerge
@@ -2162,7 +2162,7 @@ class MergeState(Block):
 
     @staticmethod
     def initialize(
-            name, merge_base,
+            git, name, merge_base,
             tip1, commits1,
             tip2, commits2,
             goal=DEFAULT_GOAL, goalopts=None,
@@ -3045,7 +3045,7 @@ def cmd_init(parser, options):
             parser.error('%s\nPerhaps use "--first-parent"?' % (e,))
 
     merge_state = MergeState.initialize(
-        options.name, merge_base,
+        git, options.name, merge_base,
         tip1, commits1,
         tip2, commits2,
         goal=options.goal, manual=options.manual,
@@ -3082,7 +3082,7 @@ def cmd_start(parser, options):
             parser.error('%s\nPerhaps use "--first-parent"?' % (e,))
 
     merge_state = MergeState.initialize(
-        options.name, merge_base,
+        git, options.name, merge_base,
         tip1, commits1,
         tip2, commits2,
         goal=options.goal, manual=options.manual,
@@ -3150,7 +3150,7 @@ def cmd_merge(parser, options):
         sys.exit(0)
 
     merge_state = MergeState.initialize(
-        name, merge_base,
+        git, name, merge_base,
         tip1, commits1,
         tip2, commits2,
         goal=options.goal, manual=options.manual,
@@ -3221,7 +3221,7 @@ def cmd_rebase(parser, options):
         sys.exit(0)
 
     merge_state = MergeState.initialize(
-        options.name, merge_base,
+        git, options.name, merge_base,
         tip1, commits1,
         tip2, commits2,
         goal=options.goal, manual=options.manual,
@@ -3343,7 +3343,7 @@ def cmd_drop(parser, options):
         sys.exit(0)
 
     merge_state = MergeState.initialize(
-        options.name, merge_base,
+        git, options.name, merge_base,
         tip1, commits1,
         tip2, commits2,
         goal='drop', goalopts={'base' : start},
@@ -3461,7 +3461,7 @@ def cmd_revert(parser, options):
         sys.exit(0)
 
     merge_state = MergeState.initialize(
-        options.name, merge_base,
+        git, options.name, merge_base,
         tip1, commits1,
         tip2, commits2,
         goal='revert',

--- a/git-imerge
+++ b/git-imerge
@@ -274,6 +274,40 @@ class InvalidBranchNameError(Failure):
     pass
 
 
+class GitTemporaryHead(object):
+    """A context manager that records the current HEAD state then restores it.
+
+    This should only be used when the working copy is clean. message
+    is used for the reflog.
+
+    """
+
+    def __enter__(self, git, message):
+        self.message = message
+        try:
+            self.head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
+        except CalledProcessError:
+            self.head_name = None
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.head_name:
+            try:
+                check_call([
+                    'git', 'symbolic-ref',
+                    '-m', self.message, 'HEAD',
+                    self.head_name,
+                    ])
+                check_call(['git', 'reset', '--hard'])
+            except CalledProcessError as e:
+                raise Failure(
+                    'Could not restore HEAD to %r!:    %s\n'
+                    % (self.head_name, e.message,)
+                    )
+
+        return False
+
+
 class GitRepository(object):
     MERGE_STATE_REFNAME_RE = re.compile(
         r"""
@@ -617,6 +651,16 @@ class GitRepository(object):
         [commit] = parents
         return commit
 
+    def temporary_head(self, message):
+        """Return a context manager to manage a temporary HEAD.
+
+        On entry, record the current HEAD state. On exit, restore it.
+        message is used for the reflog.
+
+        """
+
+        return GitTemporaryHead(self, message)
+
 
 def rev_parse(arg):
     return check_output(['git', 'rev-parse', '--verify', '--quiet', arg]).strip()
@@ -889,40 +933,6 @@ def get_boundaries(tip1, tip2, first_parent):
         raise NothingToDoError(tip2, tip1)
 
     return (merge_base, commits1, commits2)
-
-
-class TemporaryHead(object):
-    """A context manager that records the current HEAD state then restores it.
-
-    This should only be used when the working copy is clean. message
-    is used for the reflog.
-
-    """
-
-    def __enter__(self, message='imerge: restoring'):
-        self.message = message
-        try:
-            self.head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
-        except CalledProcessError:
-            self.head_name = None
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.head_name:
-            try:
-                check_call([
-                    'git', 'symbolic-ref',
-                    '-m', self.message, 'HEAD',
-                    self.head_name,
-                    ])
-                check_call(['git', 'reset', '--hard'])
-            except CalledProcessError as e:
-                raise Failure(
-                    'Could not restore HEAD to %r!:    %s\n'
-                    % (self.head_name, e.message,)
-                    )
-
-        return False
 
 
 def reparent(commit, parent_sha1s, msg=None):
@@ -3522,7 +3532,7 @@ def cmd_autofill(parser, options):
     git = GitRepository()
     git.require_clean_work_tree('proceed')
     merge_state = read_merge_state(git, options.name)
-    with TemporaryHead():
+    with git.temporary_head(message='imerge: restoring'):
         try:
             merge_state.auto_complete_frontier()
         except FrontierBlockedError as e:

--- a/git-imerge
+++ b/git-imerge
@@ -860,6 +860,18 @@ class GitRepository(object):
 
         check_call(['git', 'update-ref'] + opt + ['-m', msg, '-d', refname])
 
+    def delete_imerge_refs(self, name):
+        for line in check_output([
+                'git', 'for-each-ref', 'refs/imerge/%s' % (name,)
+                ]).splitlines():
+            (sha1, type, refname) = line.split()
+            try:
+                self.delete_ref(refname, 'imerge: remove merge %r' % (name,))
+            except CalledProcessError as e:
+                sys.stderr.write(
+                    'Warning: error removing reference %r: %s' % (refname, e)
+                    )
+
     def detach(self, msg):
         """Detach HEAD. msg is used for the reflog."""
 
@@ -2477,16 +2489,7 @@ class MergeState(Block):
             )
 
         # Remove any references referring to intermediate merges:
-        for line in check_output([
-                'git', 'for-each-ref', 'refs/imerge/%s' % (name,)
-                ]).splitlines():
-            (sha1, type, refname) = line.split()
-            try:
-                git.delete_ref(refname, 'imerge: remove merge %r' % (name,))
-            except CalledProcessError as e:
-                sys.stderr.write(
-                    'Warning: error removing reference %r: %s' % (refname, e)
-                    )
+        git.delete_imerge_refs(name)
 
         # If this merge was the default, unset the default:
         if git.get_default_imerge_name() == name:

--- a/git-imerge
+++ b/git-imerge
@@ -353,6 +353,16 @@ class GitRepository(object):
         except CalledProcessError:
             return False
 
+    def refresh_index(self):
+        process = subprocess.Popen(
+            ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+        out, err = communicate(process)
+        retcode = process.poll()
+        if retcode:
+            raise UncleanWorkTreeError(err.rstrip() or out.rstrip())
+
     def check_imerge_exists(self, name):
         """Verify that a MergeState with the given name exists.
 
@@ -461,7 +471,7 @@ class GitRepository(object):
         if retcode:
             raise UncleanWorkTreeError(err.rstrip())
 
-        refresh_index()
+        self.refresh_index()
 
         error = []
         if unstaged_changes():
@@ -501,7 +511,7 @@ class GitRepository(object):
 
         # Check if all conflicts are resolved and everything in the
         # working tree is staged:
-        refresh_index()
+        self.refresh_index()
         if unstaged_changes():
             raise UncleanWorkTreeError(
                 'Cannot proceed: You have unstaged changes.'
@@ -571,17 +581,6 @@ class GitRepository(object):
 
         [commit] = parents
         return commit
-
-
-def refresh_index():
-    process = subprocess.Popen(
-        ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
-    out, err = communicate(process)
-    retcode = process.poll()
-    if retcode:
-        raise UncleanWorkTreeError(err.rstrip() or out.rstrip())
 
 
 def unstaged_changes():

--- a/git-imerge
+++ b/git-imerge
@@ -422,6 +422,16 @@ class GitRepository(object):
         except CalledProcessError:
             raise InvalidBranchNameError('Name %r is not a valid branch name!' % (name,))
 
+    def get_commit_sha1(self, arg):
+        """Convert arg into a SHA1 and verify that it refers to a commit.
+
+        If not, raise ValueError."""
+
+        try:
+            return rev_parse('%s^{commit}' % (arg,))
+        except CalledProcessError:
+            raise ValueError('%r does not refer to a valid git commit' % (arg,))
+
     def refresh_index(self):
         process = subprocess.Popen(
             ['git', 'update-index', '-q', '--ignore-submodules', '--refresh'],
@@ -496,7 +506,7 @@ class GitRepository(object):
         """
 
         try:
-            ref_oldval = get_commit_sha1(refname)
+            ref_oldval = self.get_commit_sha1(refname)
         except ValueError:
             # refname doesn't already exist; no problem.
             return True
@@ -523,7 +533,7 @@ class GitRepository(object):
             call_silently(['git', 'reset', '--merge'])
             raise AutomaticMergeFailed(commit1, commit2)
         else:
-            return get_commit_sha1('HEAD')
+            return self.get_commit_sha1('HEAD')
 
     def require_clean_work_tree(self, action):
         """Verify that the current tree is clean.
@@ -712,17 +722,6 @@ def checkout(refname, quiet=False):
         target = '%s^0' % (refname,)
     cmd += [target]
     check_call(cmd)
-
-
-def get_commit_sha1(arg):
-    """Convert arg into a SHA1 and verify that it refers to a commit.
-
-    If not, raise ValueError."""
-
-    try:
-        return rev_parse('%s^{commit}' % (arg,))
-    except CalledProcessError:
-        raise ValueError('%r does not refer to a valid git commit' % (arg,))
 
 
 def get_commit_parents(commit):
@@ -2428,7 +2427,7 @@ class MergeState(Block):
             check_call([
                 'git', 'update-ref', '--no-deref',
                 '-m', 'Detach HEAD from %s' % (scratch_refname,),
-                'HEAD', get_commit_sha1('HEAD'),
+                'HEAD', git.get_commit_sha1('HEAD'),
                 ])
 
         # Delete the scratch refname:
@@ -2658,7 +2657,7 @@ class MergeState(Block):
         refname = MergeState.get_scratch_refname(self.name)
 
         try:
-            commit = get_commit_sha1(refname)
+            commit = self.git.get_commit_sha1(refname)
         except ValueError:
             raise NoManualMergeError('Reference %s does not exist.' % (refname,))
 
@@ -2714,7 +2713,7 @@ class MergeState(Block):
         # checked out.  Now check whether there is staged content that
         # can be committed:
         if self.git.commit_user_merge(edit_log_msg=edit_log_msg):
-            commit = get_commit_sha1('HEAD')
+            commit = self.git.get_commit_sha1('HEAD')
 
         self.git.require_clean_work_tree('proceed')
 
@@ -2751,7 +2750,7 @@ class MergeState(Block):
 
     def _set_refname(self, refname, commit, force=False):
         try:
-            ref_oldval = get_commit_sha1(refname)
+            ref_oldval = self.git.get_commit_sha1(refname)
         except ValueError:
             # refname doesn't already exist; simply point it at commit:
             check_call(['git', 'update-ref', refname, commit])
@@ -3608,12 +3607,12 @@ def cmd_diagram(parser, options):
 def cmd_reparent(parser, options):
     git = GitRepository()
     try:
-        commit_sha1 = get_commit_sha1('HEAD')
+        commit_sha1 = git.get_commit_sha1('HEAD')
     except ValueError:
         sys.exit('HEAD is not a valid commit')
 
     try:
-        parent_sha1s = [get_commit_sha1(p) for p in options.parents]
+        parent_sha1s = [git.get_commit_sha1(p) for p in options.parents]
     except ValueError as e:
         sys.exit(e.message)
 

--- a/git-imerge
+++ b/git-imerge
@@ -330,13 +330,7 @@ class GitRepository(object):
         exist, just return False.  If it exists but is unusable for
         some other reason, raise an exception."""
 
-        try:
-            call_silently(
-                ['git', 'check-ref-format', 'refs/imerge/%s' % (name,)]
-                )
-        except CalledProcessError:
-            raise Failure('Name %r is not a valid refname component!' % (name,))
-
+        self.check_imerge_name_format(name)
         state_refname = 'refs/imerge/%s/state' % (name,)
         for line in check_output(['git', 'for-each-ref', state_refname]).splitlines():
             (sha1, type, refname) = line.split()

--- a/git-imerge
+++ b/git-imerge
@@ -708,6 +708,70 @@ class GitRepository(object):
     def get_tree(self, arg):
         return rev_parse('%s^{tree}' % (arg,))
 
+    def linear_ancestry(self, commit1, commit2, first_parent):
+        """Compute a linear ancestry between commit1 and commit2.
+
+        Our goal is to find a linear series of commits connecting
+        `commit1` and `commit2`. We do so as follows:
+
+        * If all of the commits in
+
+              git rev-list --ancestry-path commit1..commit2
+
+          are on a linear chain, return that.
+
+        * If there are multiple paths between `commit1` and `commit2` in
+          that list of commits, then
+
+          * If `first_parent` is not set, then raise an
+            `NonlinearAncestryError` exception.
+
+          * If `first_parent` is set, then, at each merge commit, follow
+            the first parent that is in that list of commits.
+
+        Return a list of SHA-1s in 'chronological' order.
+
+        Raise NotFirstParentAncestorError if commit1 is not an ancestor of
+        commit2.
+
+        """
+
+        oid1 = rev_parse(commit1)
+        oid2 = rev_parse(commit2)
+
+        parentage = {oid1 : []}
+        for (commit, parents) in rev_list_with_parents(
+                '--ancestry-path', '--topo-order', '%s..%s' % (oid1, oid2)
+                ):
+            parentage[commit] = parents
+
+        commits = []
+
+        commit = oid2
+        while commit != oid1:
+            parents = parentage.get(commit, [])
+
+            # Only consider parents that are in the ancestry path:
+            included_parents = [
+                parent
+                for parent in parents
+                if parent in parentage
+            ]
+
+            if not included_parents:
+                raise NotFirstParentAncestorError(commit1, commit2)
+            elif len(included_parents) == 1 or first_parent:
+                parent = included_parents[0]
+            else:
+                raise NonlinearAncestryError(commit1, commit2)
+
+            commits.append(commit)
+            commit = parent
+
+        commits.reverse()
+
+        return commits
+
     def get_boundaries(self, tip1, tip2, first_parent):
         """Get the boundaries of an incremental merge.
 
@@ -717,11 +781,11 @@ class GitRepository(object):
 
         merge_base = compute_best_merge_base(tip1, tip2)
 
-        commits1 = linear_ancestry(merge_base, tip1, first_parent)
+        commits1 = self.linear_ancestry(merge_base, tip1, first_parent)
         if not commits1:
             raise NothingToDoError(tip1, tip2)
 
-        commits2 = linear_ancestry(merge_base, tip2, first_parent)
+        commits2 = self.linear_ancestry(merge_base, tip2, first_parent)
         if not commits2:
             raise NothingToDoError(tip2, tip1)
 
@@ -831,71 +895,6 @@ class NothingToDoError(Failure):
             'There are no commits on "%s" that are not already in "%s"'
             % (src_tip, dst_tip),
             )
-
-
-def linear_ancestry(commit1, commit2, first_parent):
-    """Compute a linear ancestry between commit1 and commit2.
-
-    Our goal is to find a linear series of commits connecting
-    `commit1` and `commit2`. We do so as follows:
-
-    * If all of the commits in
-
-          git rev-list --ancestry-path commit1..commit2
-
-      are on a linear chain, return that.
-
-    * If there are multiple paths between `commit1` and `commit2` in
-      that list of commits, then
-
-      * If `first_parent` is not set, then raise an
-        `NonlinearAncestryError` exception.
-
-      * If `first_parent` is set, then, at each merge commit, follow
-        the first parent that is in that list of commits.
-
-    Return a list of SHA-1s in 'chronological' order.
-
-    Raise NotFirstParentAncestorError if commit1 is not an ancestor of
-    commit2.
-
-    """
-
-    oid1 = rev_parse(commit1)
-    oid2 = rev_parse(commit2)
-
-    parentage = {oid1 : []}
-    for (commit, parents) in rev_list_with_parents(
-            '--ancestry-path', '--topo-order', '%s..%s' % (oid1, oid2)
-            ):
-        parentage[commit] = parents
-
-    commits = []
-
-    commit = oid2
-    while commit != oid1:
-        parents = parentage.get(commit, [])
-
-        # Only consider parents that are in the ancestry path:
-        included_parents = [
-            parent
-            for parent in parents
-            if parent in parentage
-        ]
-
-        if not included_parents:
-            raise NotFirstParentAncestorError(commit1, commit2)
-        elif len(included_parents) == 1 or first_parent:
-            parent = included_parents[0]
-        else:
-            raise NonlinearAncestryError(commit1, commit2)
-
-        commits.append(commit)
-        commit = parent
-
-    commits.reverse()
-
-    return commits
 
 
 def compute_best_merge_base(tip1, tip2):
@@ -3247,7 +3246,7 @@ def cmd_drop(parser, options):
         start = rev_parse('%s^' % (end,))
 
     try:
-        to_drop = linear_ancestry(start, end, options.first_parent)
+        to_drop = git.linear_ancestry(start, end, options.first_parent)
     except NonlinearAncestryError as e:
         if options.first_parent:
             parser.error(str(e))
@@ -3370,7 +3369,7 @@ def cmd_revert(parser, options):
         start = rev_parse('%s^' % (end,))
 
     try:
-        to_revert = linear_ancestry(start, end, options.first_parent)
+        to_revert = git.linear_ancestry(start, end, options.first_parent)
     except NonlinearAncestryError as e:
         if options.first_parent:
             parser.error(str(e))

--- a/git-imerge
+++ b/git-imerge
@@ -2523,6 +2523,115 @@ class MergeState(Block):
         self[i1, i2].record_merge(commit, MergeRecord.NEW_MANUAL)
         return (i1, i2)
 
+    def incorporate_user_merge(self, edit_log_msg=None):
+        """If the user has done a merge for us, incorporate the results.
+
+        If the scratch reference refs/heads/imerge/NAME exists and is
+        checked out, first check if there are staged changes that can
+        be committed. Then try to incorporate the current commit into
+        this MergeState, delete the reference, and return (i1,i2)
+        corresponding to the merge. If the scratch reference does not
+        exist, raise NoManualMergeError(). If the scratch reference
+        exists but cannot be used, raise a ManualMergeUnusableError.
+        If there are unstaged changes in the working tree, emit an
+        error message and raise UncleanWorkTreeError.
+
+        """
+
+        refname = MergeState.get_scratch_refname(self.name)
+
+        try:
+            commit = get_commit_sha1(refname)
+        except ValueError:
+            raise NoManualMergeError('Reference %s does not exist.' % (refname,))
+
+        try:
+            head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
+        except CalledProcessError:
+            raise NoManualMergeError('HEAD is currently detached.')
+
+        if head_name != refname:
+            # This should not usually happen.  The scratch reference
+            # exists, but it is not current.  Perhaps the user gave up on
+            # an attempted merge then switched to another branch.  We want
+            # to delete refname, but only if it doesn't contain any
+            # content that we don't already know.
+            try:
+                self.find_index(commit)
+            except CommitNotFoundError:
+                # It points to a commit that we don't have in our records.
+                raise Failure(
+                    'The scratch reference, %(refname)s, already exists but is not\n'
+                    'checked out.  If it points to a merge commit that you would like\n'
+                    'to use, please check it out using\n'
+                    '\n'
+                    '    git checkout %(refname)s\n'
+                    '\n'
+                    'and then try to continue again.  If it points to a commit that is\n'
+                    'unneeded, then please delete the reference using\n'
+                    '\n'
+                    '    git update-ref -d %(refname)s\n'
+                    '\n'
+                    'and then continue.'
+                    % dict(refname=refname)
+                    )
+            else:
+                # It points to a commit that is already recorded.  We can
+                # delete it without losing any information.
+                check_call([
+                    'git', 'update-ref',
+                    '-m',
+                    'imerge %r: Remove obsolete scratch reference'
+                    % (self.name,),
+                    '-d', refname,
+                    ])
+                sys.stderr.write(
+                    '%s did not point to a new merge; it has been deleted.\n'
+                    % (refname,)
+                    )
+                raise NoManualMergeError(
+                    'Reference %s was not checked out.' % (refname,)
+                    )
+
+        # If we reach this point, then the scratch reference exists and is
+        # checked out.  Now check whether there is staged content that
+        # can be committed:
+        if commit_user_merge(edit_log_msg=edit_log_msg):
+            commit = get_commit_sha1('HEAD')
+
+        require_clean_work_tree('proceed')
+
+        merge_frontier = MergeFrontier.map_known_frontier(self)
+
+        # This might throw ManualMergeUnusableError:
+        (i1, i2) = self.incorporate_manual_merge(commit)
+
+        # Now detach head so that we can delete refname.
+        check_call([
+            'git', 'update-ref', '--no-deref',
+            '-m', 'Detach HEAD from %s' % (refname,),
+            'HEAD', commit,
+            ])
+
+        check_call([
+            'git', 'update-ref',
+            '-m', 'imerge %s: remove scratch reference' % (self.name,),
+            '-d', refname,
+            ])
+
+        try:
+            # This might throw NotABlockingCommitError:
+            unblocked_block = merge_frontier.get_affected_blocker_block(i1, i2)
+            unblocked_block[1, 1].record_blocked(False)
+            sys.stderr.write(
+                'Merge has been recorded for merge %d-%d.\n'
+                % unblocked_block.get_original_indexes(1, 1)
+                )
+        except NotABlockingCommitError:
+            raise
+        finally:
+            self.save()
+
     def _set_refname(self, refname, commit, force=False):
         try:
             ref_oldval = get_commit_sha1(refname)
@@ -2855,114 +2964,6 @@ def commit_user_merge(edit_log_msg=None):
         raise Failure('Could not commit staged changes.')
 
     return True
-
-
-def incorporate_user_merge(merge_state, edit_log_msg=None):
-    """If the user has done a merge for us, incorporate the results.
-
-    If the scratch reference refs/heads/imerge/NAME exists and is
-    checked out, first check if there are staged changes that can be
-    committed.  Then try to incorporate the current commit into
-    merge_state, delete the reference, and return (i1,i2)
-    corresponding to the merge.  If the scratch reference does not
-    exist, raise NoManualMergeError().  If the scratch reference
-    exists but cannot be used, raise a ManualMergeUnusableError.  If
-    there are unstaged changes in the working tree, emit an error
-    message and raise UncleanWorkTreeError."""
-
-    refname = MergeState.get_scratch_refname(merge_state.name)
-
-    try:
-        commit = get_commit_sha1(refname)
-    except ValueError:
-        raise NoManualMergeError('Reference %s does not exist.' % (refname,))
-
-    try:
-        head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
-    except CalledProcessError:
-        raise NoManualMergeError('HEAD is currently detached.')
-
-    if head_name != refname:
-        # This should not usually happen.  The scratch reference
-        # exists, but it is not current.  Perhaps the user gave up on
-        # an attempted merge then switched to another branch.  We want
-        # to delete refname, but only if it doesn't contain any
-        # content that we don't already know.
-        try:
-            merge_state.find_index(commit)
-        except CommitNotFoundError:
-            # It points to a commit that we don't have in our records.
-            raise Failure(
-                'The scratch reference, %(refname)s, already exists but is not\n'
-                'checked out.  If it points to a merge commit that you would like\n'
-                'to use, please check it out using\n'
-                '\n'
-                '    git checkout %(refname)s\n'
-                '\n'
-                'and then try to continue again.  If it points to a commit that is\n'
-                'unneeded, then please delete the reference using\n'
-                '\n'
-                '    git update-ref -d %(refname)s\n'
-                '\n'
-                'and then continue.'
-                % dict(refname=refname)
-                )
-        else:
-            # It points to a commit that is already recorded.  We can
-            # delete it without losing any information.
-            check_call([
-                'git', 'update-ref',
-                '-m',
-                'imerge %r: Remove obsolete scratch reference'
-                % (merge_state.name,),
-                '-d', refname,
-                ])
-            sys.stderr.write(
-                '%s did not point to a new merge; it has been deleted.\n'
-                % (refname,)
-                )
-            raise NoManualMergeError(
-                'Reference %s was not checked out.' % (refname,)
-                )
-
-    # If we reach this point, then the scratch reference exists and is
-    # checked out.  Now check whether there is staged content that
-    # can be committed:
-    if commit_user_merge(edit_log_msg=edit_log_msg):
-        commit = get_commit_sha1('HEAD')
-
-    require_clean_work_tree('proceed')
-
-    merge_frontier = MergeFrontier.map_known_frontier(merge_state)
-
-    # This might throw ManualMergeUnusableError:
-    (i1, i2) = merge_state.incorporate_manual_merge(commit)
-
-    # Now detach head so that we can delete refname.
-    check_call([
-        'git', 'update-ref', '--no-deref',
-        '-m', 'Detach HEAD from %s' % (refname,),
-        'HEAD', commit,
-        ])
-
-    check_call([
-        'git', 'update-ref',
-        '-m', 'imerge %s: remove scratch reference' % (merge_state.name,),
-        '-d', refname,
-        ])
-
-    try:
-        # This might throw NotABlockingCommitError:
-        unblocked_block = merge_frontier.get_affected_blocker_block(i1, i2)
-        unblocked_block[1, 1].record_blocked(False)
-        sys.stderr.write(
-            'Merge has been recorded for merge %d-%d.\n'
-            % unblocked_block.get_original_indexes(1, 1)
-            )
-    except NotABlockingCommitError:
-        raise
-    finally:
-        merge_state.save()
 
 
 def choose_merge_name(git, name, default_to_unique=True):
@@ -3486,7 +3487,7 @@ def cmd_continue(parser, options):
     git = GitRepository()
     merge_state = read_merge_state(git, options.name)
     try:
-        incorporate_user_merge(merge_state, edit_log_msg=options.edit)
+        merge_state.incorporate_user_merge(edit_log_msg=options.edit)
     except NoManualMergeError:
         pass
     except NotABlockingCommitError as e:
@@ -3506,7 +3507,7 @@ def cmd_record(parser, options):
     git = GitRepository()
     merge_state = read_merge_state(git, options.name)
     try:
-        incorporate_user_merge(merge_state, edit_log_msg=options.edit)
+        merge_state.incorporate_user_merge(edit_log_msg=options.edit)
     except NoManualMergeError as e:
         raise Failure(str(e))
     except NotABlockingCommitError:

--- a/git-imerge
+++ b/git-imerge
@@ -521,6 +521,87 @@ class GitRepository(object):
 
         return state
 
+    def read_imerge_state(self, name):
+        """Read the state associated with the specified imerge.
+
+        Return the tuple
+
+            (state_dict, {(i1, i2) : (sha1, source), ...})
+
+        , where source is 'auto' or 'manual'. Validity is checked only
+        lightly.
+
+        """
+
+        merge_ref_re = re.compile(
+            r"""
+            ^
+            refs\/imerge\/
+            """ + re.escape(name) + r"""
+            \/(?P<source>auto|manual)\/
+            (?P<i1>0|[1-9][0-9]*)
+            \-
+            (?P<i2>0|[1-9][0-9]*)
+            $
+            """,
+            re.VERBOSE,
+            )
+
+        state_ref_re = re.compile(
+            r"""
+            ^
+            refs\/imerge\/
+            """ + re.escape(name) + r"""
+            \/state
+            $
+            """,
+            re.VERBOSE,
+            )
+
+        state = None
+
+        # A map {(i1, i2) : (sha1, source)}:
+        merges = {}
+
+        # refnames that were found but not understood:
+        unexpected = []
+
+        for line in check_output([
+                'git', 'for-each-ref', 'refs/imerge/%s' % (name,)
+                ]).splitlines():
+            (sha1, type, refname) = line.split()
+            m = merge_ref_re.match(refname)
+            if m:
+                if type != 'commit':
+                    raise Failure('Reference %r is not a commit!' % (refname,))
+                i1, i2 = int(m.group('i1')), int(m.group('i2'))
+                source = m.group('source')
+                merges[i1, i2] = (sha1, source)
+                continue
+
+            m = state_ref_re.match(refname)
+            if m:
+                if type != 'blob':
+                    raise Failure('Reference %r is not a blob!' % (refname,))
+                state = self.read_imerge_state_dict(name)
+                continue
+
+            unexpected.append(refname)
+
+        if state is None:
+            raise Failure(
+                'No state found; it should have been a blob reference at '
+                '"refs/imerge/%s/state"' % (name,)
+                )
+
+        if unexpected:
+            raise Failure(
+                'Unexpected reference(s) found in "refs/imerge/%s" namespace:\n    %s\n'
+                % (name, '\n    '.join(unexpected),)
+                )
+
+        return (state, merges)
+
     def write_imerge_state_dict(self, name, state):
         state_string = json.dumps(state, sort_keys=True) + '\n'
 
@@ -2272,74 +2353,16 @@ class MergeState(Block):
 
     @staticmethod
     def read(git, name):
-        merge_ref_re = re.compile(
-            r"""
-            ^
-            refs\/imerge\/
-            """ + re.escape(name) + r"""
-            \/(?P<source>auto|manual)\/
-            (?P<i1>0|[1-9][0-9]*)
-            \-
-            (?P<i2>0|[1-9][0-9]*)
-            $
-            """,
-            re.VERBOSE,
-            )
+        (state, merges) = git.read_imerge_state(name)
 
-        state_ref_re = re.compile(
-            r"""
-            ^
-            refs\/imerge\/
-            """ + re.escape(name) + r"""
-            \/state
-            $
-            """,
-            re.VERBOSE,
-            )
-
-        state = None
-
-        # A map {(i1, i2) : (sha1, source)}:
-        merges = {}
-
-        # refnames that were found but not understood:
-        unexpected = []
-
-        for line in check_output([
-                'git', 'for-each-ref', 'refs/imerge/%s' % (name,)
-                ]).splitlines():
-            (sha1, type, refname) = line.split()
-            m = merge_ref_re.match(refname)
-            if m:
-                if type != 'commit':
-                    raise Failure('Reference %r is not a commit!' % (refname,))
-                i1, i2 = int(m.group('i1')), int(m.group('i2'))
-                source = MergeState.SOURCE_TABLE[m.group('source')]
-                merges[i1, i2] = (sha1, source)
-                continue
-
-            m = state_ref_re.match(refname)
-            if m:
-                if type != 'blob':
-                    raise Failure('Reference %r is not a blob!' % (refname,))
-                state = git.read_imerge_state_dict(name)
-                continue
-
-            unexpected.append(refname)
-
-        if state is None:
-            raise Failure(
-                'No state found; it should have been a blob reference at '
-                '"refs/imerge/%s/state"' % (name,)
-                )
+        # Translate sources from strings into MergeRecord constants
+        # SAVED_AUTO or SAVED_MANUAL:
+        merges = dict((
+            ((i1, i2), (sha1, MergeState.SOURCE_TABLE[source]))
+            for ((i1, i2), (sha1, source)) in merges.items()
+            ))
 
         blockers = state.get('blockers', [])
-
-        if unexpected:
-            raise Failure(
-                'Unexpected reference(s) found in "refs/imerge/%s" namespace:\n    %s\n'
-                % (name, '\n    '.join(unexpected),)
-                )
 
         # Find merge_base, commits1, and commits2:
         (merge_base, source) = merges.pop((0, 0))

--- a/git-imerge
+++ b/git-imerge
@@ -861,10 +861,9 @@ class GitRepository(object):
         check_call(['git', 'update-ref'] + opt + ['-m', msg, '-d', refname])
 
     def delete_imerge_refs(self, name):
-        for line in check_output([
-                'git', 'for-each-ref', 'refs/imerge/%s' % (name,)
+        for refname in check_output([
+                'git', 'for-each-ref', '--format=%(refname)', 'refs/imerge/%s' % (name,)
                 ]).splitlines():
-            (sha1, type, refname) = line.split()
             try:
                 self.delete_ref(refname, 'imerge: remove merge %r' % (name,))
             except CalledProcessError as e:

--- a/git-imerge
+++ b/git-imerge
@@ -497,7 +497,7 @@ class GitRepository(object):
         for line in check_output(['git', 'for-each-ref', state_refname]).splitlines():
             (sha1, type, refname) = line.split()
             if refname == state_refname and type == 'blob':
-                MergeState._read_state(self, name)
+                self.read_imerge_state_dict(name)
                 # If that didn't throw an exception:
                 return True
         else:
@@ -2227,10 +2227,6 @@ class MergeState(Block):
         return 'refs/heads/imerge/%s' % (name,)
 
     @staticmethod
-    def _read_state(git, name):
-        return git.read_imerge_state_dict(name)
-
-    @staticmethod
     def _check_no_merges(git, commits):
         multiparent_commits = [
             commit
@@ -2326,7 +2322,7 @@ class MergeState(Block):
             if m:
                 if type != 'blob':
                     raise Failure('Reference %r is not a blob!' % (refname,))
-                state = MergeState._read_state(git, name)
+                state = git.read_imerge_state_dict(name)
                 continue
 
             unexpected.append(refname)

--- a/git-imerge
+++ b/git-imerge
@@ -641,7 +641,7 @@ class GitRepository(object):
 
         for (commit, metadata) in path:
             if reusing:
-                if commit == metadata and get_commit_parents(commit) == parents:
+                if commit == metadata and self.get_commit_parents(commit) == parents:
                     # We can reuse this commit, too.
                     parents = [commit]
                     continue
@@ -660,6 +660,13 @@ class GitRepository(object):
 
         [commit] = parents
         return commit
+
+    def get_commit_parents(self, commit):
+        """Return a list containing the parents of commit."""
+
+        return check_output(
+            ['git', '--no-pager', 'log', '--no-walk', '--pretty=format:%P', commit]
+            ).strip().split()
 
     def get_boundaries(self, tip1, tip2, first_parent):
         """Get the boundaries of an incremental merge.
@@ -741,14 +748,6 @@ def checkout(refname, quiet=False):
         target = '%s^0' % (refname,)
     cmd += [target]
     check_call(cmd)
-
-
-def get_commit_parents(commit):
-    """Return a list containing the parents of commit."""
-
-    return check_output(
-        ['git', '--no-pager', 'log', '--no-walk', '--pretty=format:%P', commit]
-        ).strip().split()
 
 
 def get_log_message(commit):
@@ -2228,7 +2227,7 @@ class MergeState(Block):
         multiparent_commits = [
             commit
             for commit in commits
-            if len(get_commit_parents(commit)) > 1
+            if len(git.get_commit_parents(commit)) > 1
             ]
         if multiparent_commits:
             raise Failure(
@@ -2608,7 +2607,7 @@ class MergeState(Block):
         commit is not usable for some reason, raise
         ManualMergeUnusableError."""
 
-        parents = get_commit_parents(commit)
+        parents = self.git.get_commit_parents(commit)
         if len(parents) < 2:
             raise ManualMergeUnusableError('it is not a merge', commit)
         if len(parents) > 2:
@@ -3322,7 +3321,7 @@ def cmd_drop(parser, options):
     checkout(end)
     for commit in reversed(to_drop):
         cmd = ['git', 'revert', '--no-edit']
-        if len(get_commit_parents(commit)) > 1:
+        if len(git.get_commit_parents(commit)) > 1:
             cmd += ['-m', '1']
         cmd += [commit]
         check_call(cmd)
@@ -3440,7 +3439,7 @@ def cmd_revert(parser, options):
     checkout(end)
     for commit in reversed(to_revert):
         cmd = ['git', 'revert', '--no-edit']
-        if len(get_commit_parents(commit)) > 1:
+        if len(git.get_commit_parents(commit)) > 1:
             cmd += ['-m', '1']
         cmd += [commit]
         check_call(cmd)

--- a/git-imerge
+++ b/git-imerge
@@ -676,6 +676,14 @@ class GitRepository(object):
             for l in check_output(cmd).splitlines()
             ]
 
+    def rev_list_with_parents(self, *args):
+        """Iterate over (commit, [parent,...])."""
+
+        cmd = ['git', 'log', '--format=%H %P'] + list(args)
+        for line in check_output(cmd).splitlines():
+            commits = line.strip().split()
+            yield (commits[0], commits[1:])
+
     def get_author_info(self, commit):
         """Return environment settings to set author metadata.
 
@@ -747,7 +755,7 @@ class GitRepository(object):
         oid2 = rev_parse(commit2)
 
         parentage = {oid1 : []}
-        for (commit, parents) in rev_list_with_parents(
+        for (commit, parents) in self.rev_list_with_parents(
                 '--ancestry-path', '--topo-order', '%s..%s' % (oid1, oid2)
                 ):
             parentage[commit] = parents
@@ -843,15 +851,6 @@ class GitRepository(object):
 
 def rev_parse(arg):
     return check_output(['git', 'rev-parse', '--verify', '--quiet', arg]).strip()
-
-
-def rev_list_with_parents(*args):
-    """Iterate over (commit, [parent,...])."""
-
-    cmd = ['git', 'log', '--format=%H %P'] + list(args)
-    for line in check_output(cmd).splitlines():
-        commits = line.strip().split()
-        yield (commits[0], commits[1:])
 
 
 BRANCH_PREFIX = 'refs/heads/'

--- a/git-imerge
+++ b/git-imerge
@@ -861,15 +861,30 @@ class GitRepository(object):
         check_call(['git', 'update-ref'] + opt + ['-m', msg, '-d', refname])
 
     def delete_imerge_refs(self, name):
-        for refname in check_output([
-                'git', 'for-each-ref', '--format=%(refname)', 'refs/imerge/%s' % (name,)
-                ]).splitlines():
-            try:
-                self.delete_ref(refname, 'imerge: remove merge %r' % (name,))
-            except CalledProcessError as e:
-                sys.stderr.write(
-                    'Warning: error removing reference %r: %s' % (refname, e)
-                    )
+        stdin = ''.join(
+            'delete %s\n' % (refname,)
+            for refname in check_output([
+                    'git', 'for-each-ref',
+                    '--format=%(refname)',
+                    'refs/imerge/%s' % (name,)
+                    ]).splitlines()
+            )
+
+        process = subprocess.Popen(
+            [
+                'git', 'update-ref',
+                '-m', 'imerge: remove merge %r' % (name,),
+                '--stdin',
+                ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+        out = communicate(process, input=stdin)[0]
+        retcode = process.poll()
+        if retcode:
+            sys.stderr.write(
+                'Warning: error removing references:\n%s' % (out,)
+                )
 
     def detach(self, msg):
         """Detach HEAD. msg is used for the reflog."""

--- a/git-imerge
+++ b/git-imerge
@@ -2188,7 +2188,7 @@ class MergeState(Block):
             )
 
     @staticmethod
-    def read(name):
+    def read(git, name):
         merge_ref_re = re.compile(
             r"""
             ^
@@ -3000,6 +3000,7 @@ def choose_merge_name(git, name, default_to_unique=True):
 
 def read_merge_state(git, name=None, default_to_unique=True):
     return MergeState.read(
+        git,
         choose_merge_name(git, name, default_to_unique=default_to_unique),
         )
 

--- a/git-imerge
+++ b/git-imerge
@@ -2181,7 +2181,7 @@ class MergeState(Block):
             MergeState._check_no_merges(commits2)
 
         return MergeState(
-            name, merge_base,
+            git, name, merge_base,
             tip1, commits1,
             tip2, commits2,
             MergeRecord.NEW_MANUAL,
@@ -2298,7 +2298,7 @@ class MergeState(Block):
         branch = state.get('branch', name)
 
         state = MergeState(
-            name, merge_base,
+            git, name, merge_base,
             tip1, commits1,
             tip2, commits2,
             MergeRecord.SAVED_MANUAL,
@@ -2377,7 +2377,7 @@ class MergeState(Block):
             git.set_default_imerge_name(None)
 
     def __init__(
-            self, name, merge_base,
+            self, git, name, merge_base,
             tip1, commits1,
             tip2, commits2,
             source,

--- a/git-imerge
+++ b/git-imerge
@@ -1057,7 +1057,7 @@ class MergeRecord(object):
     def is_manual(self):
         return self.flags & self.MANUAL != 0
 
-    def save(self, name, i1, i2):
+    def save(self, git, name, i1, i2):
         """If this record has changed, save it."""
 
         def set_ref(source):
@@ -2933,7 +2933,7 @@ class MergeState(Block):
             for i1 in range(0, self.len1):
                 record = self[i1, i2]
                 if record.is_known():
-                    record.save(self.name, i1, i2)
+                    record.save(self.git, self.name, i1, i2)
                 if record.is_blocked():
                     blockers.append((i1, i2))
 

--- a/git-imerge
+++ b/git-imerge
@@ -656,9 +656,7 @@ class GitRepository(object):
         try:
             call_silently(cmd)
         except CalledProcessError:
-            # We don't use "git merge --abort" here because it was only
-            # added in git version 1.7.4.
-            call_silently(['git', 'reset', '--merge'])
+            self.abort_merge()
             raise AutomaticMergeFailed(commit1, commit2)
         else:
             return self.get_commit_sha1('HEAD')
@@ -866,6 +864,11 @@ class GitRepository(object):
         """Detach HEAD. msg is used for the reflog."""
 
         self.update_ref('HEAD', 'HEAD^0', msg, deref=False)
+
+    def abort_merge(self):
+        # We don't use "git merge --abort" here because it was
+        # only added in git version 1.7.4.
+        check_call(['git', 'reset', '--merge'])
 
     def compute_best_merge_base(self, tip1, tip2):
         try:
@@ -2460,12 +2463,9 @@ class MergeState(Block):
         # If HEAD is the scratch refname, abort any in-progress
         # commits and detach HEAD:
         scratch_refname = MergeState.get_scratch_refname(name)
-        head_refname = git.get_head_refname()
-        if head_refname == scratch_refname:
+        if git.get_head_refname() == scratch_refname:
             try:
-                # We don't use "git merge --abort" here because it was
-                # only added in git version 1.7.4.
-                check_call(['git', 'reset', '--merge'])
+                git.abort_merge()
             except CalledProcessError:
                 pass
             # Detach head so that we can delete scratch_refname:

--- a/git-imerge
+++ b/git-imerge
@@ -669,6 +669,13 @@ class GitRepository(object):
         [commit] = parents
         return commit
 
+    def rev_list(self, *args):
+        cmd = ['git', 'rev-list'] + list(args)
+        return [
+            l.strip()
+            for l in check_output(cmd).splitlines()
+            ]
+
     def get_author_info(self, commit):
         """Return environment settings to set author metadata.
 
@@ -836,14 +843,6 @@ class GitRepository(object):
 
 def rev_parse(arg):
     return check_output(['git', 'rev-parse', '--verify', '--quiet', arg]).strip()
-
-
-def rev_list(*args):
-    cmd = ['git', 'rev-list'] + list(args)
-    return [
-        l.strip()
-        for l in check_output(cmd).splitlines()
-        ]
 
 
 def rev_list_with_parents(*args):

--- a/git-imerge
+++ b/git-imerge
@@ -653,13 +653,22 @@ class GitRepository(object):
             tree = get_tree(commit)
             new_commit = commit_tree(
                 tree, parents,
-                msg=get_log_message(metadata),
+                msg=self.get_log_message(metadata),
                 metadata=get_author_info(metadata),
                 )
             parents = [new_commit]
 
         [commit] = parents
         return commit
+
+    def get_log_message(self, commit):
+        contents = check_output([
+            'git', 'cat-file', 'commit', commit,
+            ]).splitlines(True)
+        contents = contents[contents.index('\n') + 1:]
+        if contents and contents[-1][-1:] != '\n':
+            contents.append('\n')
+        return ''.join(contents)
 
     def get_commit_parents(self, commit):
         """Return a list containing the parents of commit."""
@@ -748,16 +757,6 @@ def checkout(refname, quiet=False):
         target = '%s^0' % (refname,)
     cmd += [target]
     check_call(cmd)
-
-
-def get_log_message(commit):
-    contents = check_output([
-        'git', 'cat-file', 'commit', commit,
-        ]).splitlines(True)
-    contents = contents[contents.index('\n') + 1:]
-    if contents and contents[-1][-1:] != '\n':
-        contents.append('\n')
-    return ''.join(contents)
 
 
 def get_author_info(commit):
@@ -2807,7 +2806,7 @@ class MergeState(Block):
 
             # Create a commit, copying the old log message:
             msg = (
-                get_log_message(orig).rstrip('\n')
+                self.git.get_log_message(orig).rstrip('\n')
                 + '\n\n(rebased-with-history from commit %s)\n' % orig
                 )
             commit = commit_tree(tree, [commit, orig], msg=msg)

--- a/git-imerge
+++ b/git-imerge
@@ -262,6 +262,14 @@ class UncleanWorkTreeError(Failure):
     pass
 
 
+class AutomaticMergeFailed(Exception):
+    def __init__(self, commit1, commit2):
+        Exception.__init__(
+            self, 'Automatic merge of %s and %s failed' % (commit1, commit2,)
+            )
+        self.commit1, self.commit2 = commit1, commit2
+
+
 class GitRepository(object):
     MERGE_STATE_REFNAME_RE = re.compile(
         r"""
@@ -375,6 +383,28 @@ class GitRepository(object):
             return True
         else:
             return self.is_ancestor(ref_oldval, commit)
+
+    def automerge(self, commit1, commit2, msg=None):
+        """Attempt an automatic merge of commit1 and commit2.
+
+        Return the SHA1 of the resulting commit, or raise
+        AutomaticMergeFailed on error.  This must be called with a clean
+        worktree."""
+
+        call_silently(['git', 'checkout', '-f', commit1])
+        cmd = ['git', '-c', 'rerere.enabled=false', 'merge']
+        if msg is not None:
+            cmd += ['-m', msg]
+        cmd += [commit2]
+        try:
+            call_silently(cmd)
+        except CalledProcessError:
+            # We don't use "git merge --abort" here because it was only
+            # added in git version 1.7.4.
+            call_silently(['git', 'reset', '--merge'])
+            raise AutomaticMergeFailed(commit1, commit2)
+        else:
+            return get_commit_sha1('HEAD')
 
 
 def get_default_edit():
@@ -882,37 +912,6 @@ def create_commit_chain(base, path):
 
     [commit] = parents
     return commit
-
-
-class AutomaticMergeFailed(Exception):
-    def __init__(self, commit1, commit2):
-        Exception.__init__(
-            self, 'Automatic merge of %s and %s failed' % (commit1, commit2,)
-            )
-        self.commit1, self.commit2 = commit1, commit2
-
-
-def automerge(commit1, commit2, msg=None):
-    """Attempt an automatic merge of commit1 and commit2.
-
-    Return the SHA1 of the resulting commit, or raise
-    AutomaticMergeFailed on error.  This must be called with a clean
-    worktree."""
-
-    call_silently(['git', 'checkout', '-f', commit1])
-    cmd = ['git', '-c', 'rerere.enabled=false', 'merge']
-    if msg is not None:
-        cmd += ['-m', msg]
-    cmd += [commit2]
-    try:
-        call_silently(cmd)
-    except CalledProcessError:
-        # We don't use "git merge --abort" here because it was only
-        # added in git version 1.7.4.
-        call_silently(['git', 'reset', '--merge'])
-        raise AutomaticMergeFailed(commit1, commit2)
-    else:
-        return get_commit_sha1('HEAD')
 
 
 class MergeRecord(object):
@@ -1839,7 +1838,7 @@ class Block(object):
                 'Attempting automerge of %d-%d...' % self.get_original_indexes(i1, i2)
                 )
             try:
-                automerge(self[i1, 0].sha1, self[0, i2].sha1)
+                self.git.automerge(self[i1, 0].sha1, self[0, i2].sha1)
                 sys.stderr.write('success.\n')
                 return True
             except AutomaticMergeFailed:
@@ -1862,7 +1861,7 @@ class Block(object):
             sys.stderr.write(msg % (i1orig, i2orig))
             logmsg = 'imerge \'%s\': automatic merge %d-%d' % (self.name, i1orig, i2orig)
             try:
-                merge = automerge(commit1, commit2, msg=logmsg)
+                merge = self.git.automerge(commit1, commit2, msg=logmsg)
                 sys.stderr.write('success.\n')
             except AutomaticMergeFailed as e:
                 sys.stderr.write('unexpected conflict.  Backtracking...\n')
@@ -1936,7 +1935,7 @@ class Block(object):
         sys.stderr.write('Attempting to merge %d-%d...' % (i1orig, i2orig))
         logmsg = 'imerge \'%s\': automatic merge %d-%d' % (self.name, i1orig, i2orig)
         try:
-            merge = automerge(
+            merge = self.git.automerge(
                 self[i1, i2 - 1].sha1,
                 self[i1 - 1, i2].sha1,
                 msg=logmsg,

--- a/git-imerge
+++ b/git-imerge
@@ -274,6 +274,33 @@ class InvalidBranchNameError(Failure):
     pass
 
 
+class NotFirstParentAncestorError(Failure):
+    def __init__(self, commit1, commit2):
+        Failure.__init__(
+            self,
+            'Commit "%s" is not a first-parent ancestor of "%s"'
+            % (commit1, commit2),
+            )
+
+
+class NonlinearAncestryError(Failure):
+    def __init__(self, commit1, commit2):
+        Failure.__init__(
+            self,
+            'The history "%s..%s" is not linear'
+            % (commit1, commit2),
+            )
+
+
+class NothingToDoError(Failure):
+    def __init__(self, src_tip, dst_tip):
+        Failure.__init__(
+            self,
+            'There are no commits on "%s" that are not already in "%s"'
+            % (src_tip, dst_tip),
+            )
+
+
 class GitTemporaryHead(object):
     """A context manager that records the current HEAD state then restores it.
 
@@ -863,33 +890,6 @@ class GitRepository(object):
         """
 
         return GitTemporaryHead(self, message)
-
-
-class NotFirstParentAncestorError(Failure):
-    def __init__(self, commit1, commit2):
-        Failure.__init__(
-            self,
-            'Commit "%s" is not a first-parent ancestor of "%s"'
-            % (commit1, commit2),
-            )
-
-
-class NonlinearAncestryError(Failure):
-    def __init__(self, commit1, commit2):
-        Failure.__init__(
-            self,
-            'The history "%s..%s" is not linear'
-            % (commit1, commit2),
-            )
-
-
-class NothingToDoError(Failure):
-    def __init__(self, src_tip, dst_tip):
-        Failure.__init__(
-            self,
-            'There are no commits on "%s" that are not already in "%s"'
-            % (src_tip, dst_tip),
-            )
 
 
 def compute_best_merge_base(tip1, tip2):

--- a/git-imerge
+++ b/git-imerge
@@ -311,10 +311,7 @@ class GitTemporaryHead(object):
 
     def __enter__(self, git, message):
         self.message = message
-        try:
-            self.head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
-        except CalledProcessError:
-            self.head_name = None
+        self.head_name = git.get_head_refname()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -976,6 +973,21 @@ class GitRepository(object):
             raise NothingToDoError(tip2, tip1)
 
         return (merge_base, commits1, commits2)
+
+    def get_head_refname(self, short=False):
+        """Return the name of the reference that is currently checked out.
+
+        If `short` is set, return it as a branch name. If HEAD is
+        currently detached, return None."""
+
+        cmd = ['git', 'symbolic-ref', '--quiet']
+        if short:
+            cmd += ['--short']
+        cmd += ['HEAD']
+        try:
+            return check_output(cmd).strip()
+        except CalledProcessError:
+            return None
 
     def checkout(self, refname, quiet=False):
         cmd = ['git', 'checkout']
@@ -2434,10 +2446,7 @@ class MergeState(Block):
         # If HEAD is the scratch refname, abort any in-progress
         # commits and detach HEAD:
         scratch_refname = MergeState.get_scratch_refname(name)
-        try:
-            head_refname = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
-        except CalledProcessError:
-            head_refname = None
+        head_refname = git.get_head_refname()
         if head_refname == scratch_refname:
             try:
                 # We don't use "git merge --abort" here because it was
@@ -2676,12 +2685,10 @@ class MergeState(Block):
         except ValueError:
             raise NoManualMergeError('Reference %s does not exist.' % (refname,))
 
-        try:
-            head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
-        except CalledProcessError:
+        head_name = self.git.get_head_refname()
+        if head_name is None:
             raise NoManualMergeError('HEAD is currently detached.')
-
-        if head_name != refname:
+        elif head_name != refname:
             # This should not usually happen.  The scratch reference
             # exists, but it is not current.  Perhaps the user gave up on
             # an attempted merge then switched to another branch.  We want
@@ -2767,10 +2774,7 @@ class MergeState(Block):
             # refname already exists.  This has two ramifications:
             # 1. HEAD might point at it
             # 2. We may only fast-forward it (unless force is set)
-            try:
-                head_refname = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
-            except CalledProcessError:
-                head_refname = None
+            head_refname = self.git.get_head_refname()
 
             if not force:
                 if not self.git.is_ancestor(ref_oldval, commit):
@@ -3034,12 +3038,7 @@ def cmd_init(parser, options):
         parser.error(
             'Please specify the --name to be used for this incremental merge'
             )
-    try:
-        tip1 = check_output(
-            ['git', 'symbolic-ref', '--quiet', '--short', 'HEAD'],
-            ).strip()
-    except CalledProcessError:
-        tip1 = 'HEAD'
+    tip1 = git.get_head_refname(short=True) or 'HEAD'
     tip2 = options.tip2
     try:
         (merge_base, commits1, commits2) = git.get_boundaries(
@@ -3070,12 +3069,7 @@ def cmd_start(parser, options):
         parser.error(
             'Please specify the --name to be used for this incremental merge'
             )
-    try:
-        tip1 = check_output(
-            ['git', 'symbolic-ref', '--quiet', '--short', 'HEAD'],
-            ).strip()
-    except CalledProcessError:
-        tip1 = 'HEAD'
+    tip1 = git.get_head_refname(short=True) or 'HEAD'
     tip2 = options.tip2
 
     try:
@@ -3119,10 +3113,8 @@ def cmd_merge(parser, options):
         name = tip2
         git.check_imerge_name_format(name)
 
-    try:
-        tip1 = check_output(
-            ['git', 'symbolic-ref', '--quiet', '--short', 'HEAD'],
-            ).strip()
+    tip1 = git.get_head_refname(short=True)
+    if tip1:
         if not options.branch:
             # See if we can store the result to the checked-out branch:
             try:
@@ -3131,7 +3123,7 @@ def cmd_merge(parser, options):
                 pass
             else:
                 options.branch = tip1
-    except CalledProcessError:
+    else:
         tip1 = 'HEAD'
 
     if not options.branch:
@@ -3180,10 +3172,8 @@ def cmd_rebase(parser, options):
 
     tip1 = options.tip1
 
-    try:
-        tip2 = check_output(
-            ['git', 'symbolic-ref', '--quiet', '--short', 'HEAD'],
-            ).strip()
+    tip2 = git.get_head_refname(short=True)
+    if tip2:
         if not options.branch:
             # See if we can store the result to the current branch:
             try:
@@ -3195,8 +3185,7 @@ def cmd_rebase(parser, options):
         if not options.name:
             # By default, name the imerge after the branch being rebased:
             options.name = tip2
-
-    except CalledProcessError:
+    else:
         tip2 = git.rev_parse('HEAD')
 
     if not options.name:
@@ -3289,10 +3278,8 @@ def cmd_drop(parser, options):
     #
     #     goalopts['base'] = rev_parse(commit1)
 
-    try:
-        tip1 = check_output(
-            ['git', 'symbolic-ref', '--quiet', '--short', 'HEAD'],
-            ).strip()
+    tip1 = git.get_head_refname(short=True)
+    if tip1:
         if not options.branch:
             # See if we can store the result to the current branch:
             try:
@@ -3304,8 +3291,7 @@ def cmd_drop(parser, options):
         if not options.name:
             # By default, name the imerge after the branch being rebased:
             options.name = tip1
-
-    except CalledProcessError:
+    else:
         tip1 = git.rev_parse('HEAD')
 
     if not options.name:
@@ -3407,10 +3393,8 @@ def cmd_revert(parser, options):
     #
     # Then we use imerge to rebase tip2 onto tip1.
 
-    try:
-        tip1 = check_output(
-            ['git', 'symbolic-ref', '--quiet', '--short', 'HEAD'],
-            ).strip()
+    tip1 = git.get_head_refname(short=True)
+    if tip1:
         if not options.branch:
             # See if we can store the result to the current branch:
             try:
@@ -3422,8 +3406,7 @@ def cmd_revert(parser, options):
         if not options.name:
             # By default, name the imerge after the branch being rebased:
             options.name = tip1
-
-    except CalledProcessError:
+    else:
         tip1 = git.rev_parse('HEAD')
 
     if not options.name:

--- a/git-imerge
+++ b/git-imerge
@@ -651,7 +651,7 @@ class GitRepository(object):
             # Create a commit, copying the old log message and author info
             # from the metadata commit:
             tree = get_tree(commit)
-            new_commit = commit_tree(
+            new_commit = self.commit_tree(
                 tree, parents,
                 msg=self.get_log_message(metadata),
                 metadata=self.get_author_info(metadata),
@@ -716,6 +716,38 @@ class GitRepository(object):
 
         return (merge_base, commits1, commits2)
 
+    def commit_tree(self, tree, parents, msg, metadata=None):
+        """Create a commit containing the specified tree.
+
+        metadata can be author or committer information to be added to the
+        environment, as str objects; e.g., {'GIT_AUTHOR_NAME' : 'me'}.
+
+        Return the SHA-1 of the new commit object."""
+
+        cmd = ['git', 'commit-tree', tree]
+        for parent in parents:
+            cmd += ['-p', parent]
+
+        if metadata is not None:
+            env = os.environ.copy()
+            env.update(metadata)
+        else:
+            env = os.environ
+
+        process = subprocess.Popen(
+            cmd, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            )
+        out = communicate(process, input=msg)[0]
+        retcode = process.poll()
+
+        if retcode:
+            # We don't store the output in the CalledProcessError because
+            # the "output" keyword parameter was not supported in Python
+            # 2.6:
+            raise CalledProcessError(retcode, cmd)
+
+        return out.strip()
+
     def temporary_head(self, message):
         """Return a context manager to manage a temporary HEAD.
 
@@ -777,39 +809,6 @@ def checkout(refname, quiet=False):
         target = '%s^0' % (refname,)
     cmd += [target]
     check_call(cmd)
-
-
-def commit_tree(tree, parents, msg, metadata=None):
-    """Create a commit containing the specified tree.
-
-    metadata can be author or committer information to be added to the
-    environment, as str objects; e.g., {'GIT_AUTHOR_NAME' : 'me'}.
-
-    Return the SHA-1 of the new commit object."""
-
-    cmd = ['git', 'commit-tree', tree]
-    for parent in parents:
-        cmd += ['-p', parent]
-
-    if metadata is not None:
-        env = os.environ.copy()
-        env.update(metadata)
-    else:
-        env = os.environ
-
-    process = subprocess.Popen(
-        cmd, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-        )
-    out = communicate(process, input=msg)[0]
-    retcode = process.poll()
-
-    if retcode:
-        # We don't store the output in the CalledProcessError because
-        # the "output" keyword parameter was not supported in Python
-        # 2.6:
-        raise CalledProcessError(retcode, cmd)
-
-    return out.strip()
 
 
 class NotFirstParentAncestorError(Failure):
@@ -2808,7 +2807,7 @@ class MergeState(Block):
                 self.git.get_log_message(orig).rstrip('\n')
                 + '\n\n(rebased-with-history from commit %s)\n' % orig
                 )
-            commit = commit_tree(tree, [commit, orig], msg=msg)
+            commit = self.git.commit_tree(tree, [commit, orig], msg=msg)
 
         self._set_refname(refname, commit, force=force)
 
@@ -2907,7 +2906,7 @@ class MergeState(Block):
         parents = [self[-1, 0].sha1, self[0, -1].sha1]
 
         # Create a preliminary commit with a generic commit message:
-        sha1 = commit_tree(
+        sha1 = self.git.commit_tree(
             tree, parents,
             msg='Merge %s into %s (using imerge)' % (self.tip2, self.tip1),
             )

--- a/git-imerge
+++ b/git-imerge
@@ -526,6 +526,52 @@ class GitRepository(object):
 
         return True
 
+    def create_commit_chain(self, base, path):
+        """Point refname at the chain of commits indicated by path.
+
+        path is a list [(commit, metadata), ...]. Create a series of
+        commits corresponding to the entries in path. Each commit's tree
+        is taken from the corresponding old commit, and each commit's
+        metadata is taken from the corresponding metadata commit. Use base
+        as the parent of the first commit, or make the first commit a root
+        commit if base is None. Reuse existing commits from the list
+        whenever possible.
+
+        Return a commit object corresponding to the last commit in the
+        chain.
+
+        """
+
+        reusing = True
+        if base is None:
+            if not path:
+                raise ValueError('neither base nor path specified')
+            parents = []
+        else:
+            parents = [base]
+
+        for (commit, metadata) in path:
+            if reusing:
+                if commit == metadata and get_commit_parents(commit) == parents:
+                    # We can reuse this commit, too.
+                    parents = [commit]
+                    continue
+                else:
+                    reusing = False
+
+            # Create a commit, copying the old log message and author info
+            # from the metadata commit:
+            tree = get_tree(commit)
+            new_commit = commit_tree(
+                tree, parents,
+                msg=get_log_message(metadata),
+                metadata=get_author_info(metadata),
+                )
+            parents = [new_commit]
+
+        [commit] = parents
+        return commit
+
 
 def refresh_index():
     process = subprocess.Popen(
@@ -930,53 +976,6 @@ def reparent(commit, parent_sha1s, msg=None):
     if retcode:
         raise Failure('Could not reparent commit %s' % (commit,))
     return out.strip()
-
-
-def create_commit_chain(base, path):
-    """Point refname at the chain of commits indicated by path.
-
-    path is a list [(commit, metadata), ...]. Create a series of
-    commits corresponding to the entries in path. Each commit's tree
-    is taken from the corresponding old commit, and each commit's
-    metadata is taken from the corresponding metadata commit. Use base
-    as the parent of the first commit, or make the first commit a root
-    commit if base is None. Reuse existing commits from the list
-    whenever possible.
-
-    Return a commit object corresponding to the last commit in the
-    chain.
-
-    """
-
-    reusing = True
-    if base is None:
-        if not path:
-            raise ValueError('neither base nor path specified')
-        parents = []
-    else:
-        parents = [base]
-
-    for (commit, metadata) in path:
-        if reusing:
-            if commit == metadata and get_commit_parents(commit) == parents:
-                # We can reuse this commit, too.
-                parents = [commit]
-                continue
-            else:
-                reusing = False
-
-        # Create a commit, copying the old log message and author info
-        # from the metadata commit:
-        tree = get_tree(commit)
-        new_commit = commit_tree(
-            tree, parents,
-            msg=get_log_message(metadata),
-            metadata=get_author_info(metadata),
-            )
-        parents = [new_commit]
-
-    [commit] = parents
-    return commit
 
 
 class MergeRecord(object):
@@ -2854,7 +2853,7 @@ class MergeState(Block):
         # The update is OK, so here we can set force=True:
         self._set_refname(
             refname,
-            create_commit_chain(base_sha1, path_sha1),
+            self.git.create_commit_chain(base_sha1, path_sha1),
             force=True,
             )
 

--- a/git-imerge
+++ b/git-imerge
@@ -263,6 +263,17 @@ class UncleanWorkTreeError(Failure):
 
 
 class GitRepository(object):
+    MERGE_STATE_REFNAME_RE = re.compile(
+        r"""
+        ^
+        refs\/imerge\/
+        (?P<name>.+)
+        \/state
+        $
+        """,
+        re.VERBOSE,
+        )
+
     def __init__(self):
         pass
 
@@ -272,7 +283,7 @@ class GitRepository(object):
         for line in check_output(['git', 'for-each-ref', 'refs/imerge']).splitlines():
             (sha1, type, refname) = line.split()
             if type == 'blob':
-                m = MergeState.MERGE_STATE_RE.match(refname)
+                m = GitRepository.MERGE_STATE_REFNAME_RE.match(refname)
                 if m:
                     yield m.group('name')
 
@@ -2104,17 +2115,6 @@ class MergeState(Block):
         'auto': MergeRecord.SAVED_AUTO,
         'manual': MergeRecord.SAVED_MANUAL,
         }
-
-    MERGE_STATE_RE = re.compile(
-        r"""
-        ^
-        refs\/imerge\/
-        (?P<name>.+)
-        \/state
-        $
-        """,
-        re.VERBOSE,
-        )
 
     @staticmethod
     def get_scratch_refname(name):

--- a/git-imerge
+++ b/git-imerge
@@ -1722,7 +1722,8 @@ class Block(object):
 
     """
 
-    def __init__(self, name, len1, len2):
+    def __init__(self, git, name, len1, len2):
+        self.git = git
         self.name = name
         self.len1 = len1
         self.len2 = len2
@@ -2062,7 +2063,7 @@ class SubBlock(Block):
     def __init__(self, block, slice1, slice2):
         (start1, len1) = self._convert_to_slice(slice1, block.len1)
         (start2, len2) = self._convert_to_slice(slice2, block.len2)
-        Block.__init__(self, block.name, len1, len2)
+        Block.__init__(self, block.git, block.name, len1, len2)
         if isinstance(block, SubBlock):
             # Peel away one level of indirection:
             self._merge_state = block._merge_state
@@ -2385,7 +2386,7 @@ class MergeState(Block):
             manual=False,
             branch=None,
             ):
-        Block.__init__(self, name, len(commits1) + 1, len(commits2) + 1)
+        Block.__init__(self, git, name, len(commits1) + 1, len(commits2) + 1)
         self.tip1 = tip1
         self.tip2 = tip2
         self.goal = goal

--- a/git-imerge
+++ b/git-imerge
@@ -755,6 +755,31 @@ class GitRepository(object):
     def get_tree(self, arg):
         return self.rev_parse('%s^{tree}' % (arg,))
 
+    def compute_best_merge_base(self, tip1, tip2):
+        try:
+            merge_bases = check_output(['git', 'merge-base', '--all', tip1, tip2]).splitlines()
+        except CalledProcessError:
+            raise Failure('Cannot compute merge base for %r and %r' % (tip1, tip2))
+        if not merge_bases:
+            raise Failure('%r and %r do not have a common merge base' % (tip1, tip2))
+        if len(merge_bases) == 1:
+            return merge_bases[0]
+
+        # There are multiple merge bases. The "best" one is the one that
+        # is the "closest" to the tips, which we define to be the one with
+        # the fewest non-merge commits in "merge_base..tip". (It can be
+        # shown that the result is independent of which tip is used in the
+        # computation.)
+        best_base = best_count = None
+        for merge_base in merge_bases:
+            cmd = ['git', 'rev-list', '--no-merges', '--count', '%s..%s' % (merge_base, tip1)]
+            count = int(check_output(cmd).strip())
+            if best_base is None or count < best_count:
+                best_base = merge_base
+                best_count = count
+
+        return best_base
+
     def linear_ancestry(self, commit1, commit2, first_parent):
         """Compute a linear ancestry between commit1 and commit2.
 
@@ -826,7 +851,7 @@ class GitRepository(object):
         (merge_base, commits1, commits2) describing the edges of the
         imerge.  Raise Failure if there are any problems."""
 
-        merge_base = compute_best_merge_base(tip1, tip2)
+        merge_base = self.compute_best_merge_base(tip1, tip2)
 
         commits1 = self.linear_ancestry(merge_base, tip1, first_parent)
         if not commits1:
@@ -890,32 +915,6 @@ class GitRepository(object):
         """
 
         return GitTemporaryHead(self, message)
-
-
-def compute_best_merge_base(tip1, tip2):
-    try:
-        merge_bases = check_output(['git', 'merge-base', '--all', tip1, tip2]).splitlines()
-    except CalledProcessError:
-        raise Failure('Cannot compute merge base for %r and %r' % (tip1, tip2))
-    if not merge_bases:
-        raise Failure('%r and %r do not have a common merge base' % (tip1, tip2))
-    if len(merge_bases) == 1:
-        return merge_bases[0]
-
-    # There are multiple merge bases. The "best" one is the one that
-    # is the "closest" to the tips, which we define to be the one with
-    # the fewest non-merge commits in "merge_base..tip". (It can be
-    # shown that the result is independent of which tip is used in the
-    # computation.)
-    best_base = best_count = None
-    for merge_base in merge_bases:
-        cmd = ['git', 'rev-list', '--no-merges', '--count', '%s..%s' % (merge_base, tip1)]
-        count = int(check_output(cmd).strip())
-        if best_base is None or count < best_count:
-            best_base = merge_base
-            best_count = count
-
-    return best_base
 
 
 def reparent(commit, parent_sha1s, msg=None):

--- a/git-imerge
+++ b/git-imerge
@@ -406,6 +406,45 @@ class GitRepository(object):
         else:
             return get_commit_sha1('HEAD')
 
+    def commit_user_merge(self, edit_log_msg=None):
+        """If a merge is in progress and ready to be committed, commit it.
+
+        If a simple merge is in progress and any changes in the working
+        tree are staged, commit the merge commit and return True.
+        Otherwise, return False.
+
+        """
+
+        if not simple_merge_in_progress():
+            return False
+
+        # Check if all conflicts are resolved and everything in the
+        # working tree is staged:
+        refresh_index()
+        if unstaged_changes():
+            raise UncleanWorkTreeError(
+                'Cannot proceed: You have unstaged changes.'
+                )
+
+        # A merge is in progress, and either all changes have been staged
+        # or no changes are necessary. Create a merge commit.
+        cmd = ['git', 'commit', '--no-verify']
+
+        if edit_log_msg is None:
+            edit_log_msg = get_default_edit()
+
+        if edit_log_msg:
+            cmd += ['--edit']
+        else:
+            cmd += ['--no-edit']
+
+        try:
+            check_call(cmd)
+        except CalledProcessError:
+            raise Failure('Could not commit staged changes.')
+
+        return True
+
 
 def get_default_edit():
     """Should '--edit' be used when committing intermediate user merges?
@@ -2642,7 +2681,7 @@ class MergeState(Block):
         # If we reach this point, then the scratch reference exists and is
         # checked out.  Now check whether there is staged content that
         # can be committed:
-        if commit_user_merge(edit_log_msg=edit_log_msg):
+        if self.git.commit_user_merge(edit_log_msg=edit_log_msg):
             commit = get_commit_sha1('HEAD')
 
         require_clean_work_tree('proceed')
@@ -2923,46 +2962,6 @@ def simple_merge_in_progress():
         return False
 
     return len(heads) == 1
-
-
-def commit_user_merge(edit_log_msg=None):
-    """If a merge is in progress and ready to be committed, commit it.
-
-    If a simple merge is in progress and any changes in the working
-    tree are staged, commit the merge commit and return True.
-    Otherwise, return False.
-
-    """
-
-    if not simple_merge_in_progress():
-        return False
-
-    # Check if all conflicts are resolved and everything in the
-    # working tree is staged:
-    refresh_index()
-    if unstaged_changes():
-        raise UncleanWorkTreeError(
-            'Cannot proceed: You have unstaged changes.'
-            )
-
-    # A merge is in progress, and either all changes have been staged
-    # or no changes are necessary. Create a merge commit.
-    cmd = ['git', 'commit', '--no-verify']
-
-    if edit_log_msg is None:
-        edit_log_msg = get_default_edit()
-
-    if edit_log_msg:
-        cmd += ['--edit']
-    else:
-        cmd += ['--no-edit']
-
-    try:
-        check_call(cmd)
-    except CalledProcessError:
-        raise Failure('Could not commit staged changes.')
-
-    return True
 
 
 def choose_merge_name(git, name, default_to_unique=True):

--- a/git-imerge
+++ b/git-imerge
@@ -507,7 +507,19 @@ class GitRepository(object):
         state_string = check_output(
             ['git', 'cat-file', 'blob', 'refs/imerge/%s/state' % (name,)],
             )
-        return json.loads(state_string)
+        state = json.loads(state_string)
+
+        # Convert state['version'] to a tuple of integers, and verify
+        # that it is compatible with this version of the script:
+        version = tuple(int(i) for i in state['version'].split('.'))
+        if version[0] != STATE_VERSION[0] or version[1] > STATE_VERSION[1]:
+            raise Failure(
+                'The format of imerge %s (%s) is not compatible with this script version.'
+                % (name, state['version'],)
+                )
+        state['version'] = version
+
+        return state
 
     def write_imerge_state_dict(self, name, state):
         state_string = json.dumps(state, sort_keys=True) + '\n'
@@ -2216,16 +2228,7 @@ class MergeState(Block):
 
     @staticmethod
     def _read_state(git, name):
-        state = git.read_imerge_state_dict(name)
-
-        version = tuple(int(i) for i in state['version'].split('.'))
-        if version[0] != STATE_VERSION[0] or version[1] > STATE_VERSION[1]:
-            raise Failure(
-                'The format of imerge %s (%s) is not compatible with this script version.'
-                % (name, state['version'],)
-                )
-        state['version'] = version
-        return state
+        return git.read_imerge_state_dict(name)
 
     @staticmethod
     def _check_no_merges(git, commits):

--- a/git-imerge
+++ b/git-imerge
@@ -310,6 +310,7 @@ class GitTemporaryHead(object):
     """
 
     def __enter__(self, git, message):
+        self.git = git
         self.message = message
         self.head_name = git.get_head_refname()
         return self
@@ -317,12 +318,7 @@ class GitTemporaryHead(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.head_name:
             try:
-                check_call([
-                    'git', 'symbolic-ref',
-                    '-m', self.message, 'HEAD',
-                    self.head_name,
-                    ])
-                check_call(['git', 'reset', '--hard'])
+                self.git.restore_head(self.head_name, self.message)
             except CalledProcessError as e:
                 raise Failure(
                     'Could not restore HEAD to %r!:    %s\n'
@@ -988,6 +984,10 @@ class GitRepository(object):
             return check_output(cmd).strip()
         except CalledProcessError:
             return None
+
+    def restore_head(self, refname, message):
+        check_call(['git', 'symbolic-ref', '-m', message, 'HEAD', refname])
+        check_call(['git', 'reset', '--hard'])
 
     def checkout(self, refname, quiet=False):
         cmd = ['git', 'checkout']

--- a/git-imerge
+++ b/git-imerge
@@ -2220,7 +2220,7 @@ class MergeState(Block):
         return state
 
     @staticmethod
-    def _check_no_merges(commits):
+    def _check_no_merges(git, commits):
         multiparent_commits = [
             commit
             for commit in commits
@@ -2254,7 +2254,7 @@ class MergeState(Block):
             raise Failure('Name %r is already in use!' % (name,))
 
         if goal == 'rebase':
-            MergeState._check_no_merges(commits2)
+            MergeState._check_no_merges(git, commits2)
 
         return MergeState(
             git, name, merge_base,
@@ -2487,7 +2487,8 @@ class MergeState(Block):
 
         if goal == 'rebase':
             self._check_no_merges(
-                [self[0, i2].sha1 for i2 in range(1, self.len2)]
+                self.git,
+                [self[0, i2].sha1 for i2 in range(1, self.len2)],
                 )
 
         self.goal = goal

--- a/git-imerge
+++ b/git-imerge
@@ -904,6 +904,9 @@ class GitRepository(object):
     def reset_hard(self, commit):
         check_call(['git', 'reset', '--hard', commit])
 
+    def amend(self):
+        check_call(['git', 'commit', '--amend'])
+
     def abort_merge(self):
         # We don't use "git merge --abort" here because it was
         # only added in git version 1.7.4.
@@ -2962,7 +2965,7 @@ class MergeState(Block):
         self._set_refname(refname, sha1, force=force)
 
         # Now let the user edit the commit log message:
-        check_call(['git', 'commit', '--amend'])
+        self.git.amend()
 
     def simplify(self, refname, force=False):
         """Simplify this MergeState and save the result to refname.

--- a/git-imerge
+++ b/git-imerge
@@ -2807,11 +2807,10 @@ class MergeState(Block):
             # 2. We may only fast-forward it (unless force is set)
             head_refname = self.git.get_head_refname()
 
-            if not force:
-                if not self.git.is_ancestor(ref_oldval, commit):
-                    raise Failure(
-                        '%s cannot be fast-forwarded to %s!' % (refname, commit)
-                        )
+            if not force and not self.git.is_ancestor(ref_oldval, commit):
+                raise Failure(
+                    '%s cannot be fast-forwarded to %s!' % (refname, commit)
+                    )
 
             if head_refname == refname:
                 check_call(['git', 'reset', '--hard', commit])

--- a/git-imerge
+++ b/git-imerge
@@ -429,6 +429,36 @@ class GitRepository(object):
         else:
             return get_commit_sha1('HEAD')
 
+    def require_clean_work_tree(self, action):
+        """Verify that the current tree is clean.
+
+        The code is a Python translation of the git-sh-setup(1) function
+        of the same name."""
+
+        process = subprocess.Popen(
+            ['git', 'rev-parse', '--verify', 'HEAD'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+        err = communicate(process)[1]
+        retcode = process.poll()
+        if retcode:
+            raise UncleanWorkTreeError(err.rstrip())
+
+        refresh_index()
+
+        error = []
+        if unstaged_changes():
+            error.append('Cannot %s: You have unstaged changes.' % (action,))
+
+        if uncommitted_changes():
+            if not error:
+                error.append('Cannot %s: Your index contains uncommitted changes.' % (action,))
+            else:
+                error.append('Additionally, your index contains uncommitted changes.')
+
+        if error:
+            raise UncleanWorkTreeError('\n'.join(error))
+
     def simple_merge_in_progress(self):
         """Return True iff a merge (of a single branch) is in progress."""
 
@@ -512,37 +542,6 @@ def uncommitted_changes():
         return False
     except CalledProcessError:
         return True
-
-
-def require_clean_work_tree(action):
-    """Verify that the current tree is clean.
-
-    The code is a Python translation of the git-sh-setup(1) function
-    of the same name."""
-
-    process = subprocess.Popen(
-        ['git', 'rev-parse', '--verify', 'HEAD'],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
-    err = communicate(process)[1]
-    retcode = process.poll()
-    if retcode:
-        raise UncleanWorkTreeError(err.rstrip())
-
-    refresh_index()
-
-    error = []
-    if unstaged_changes():
-        error.append('Cannot %s: You have unstaged changes.' % (action,))
-
-    if uncommitted_changes():
-        if not error:
-            error.append('Cannot %s: Your index contains uncommitted changes.' % (action,))
-        else:
-            error.append('Additionally, your index contains uncommitted changes.')
-
-    if error:
-        raise UncleanWorkTreeError('\n'.join(error))
 
 
 class InvalidBranchNameError(Failure):
@@ -2694,7 +2693,7 @@ class MergeState(Block):
         if self.git.commit_user_merge(edit_log_msg=edit_log_msg):
             commit = get_commit_sha1('HEAD')
 
-        require_clean_work_tree('proceed')
+        self.git.require_clean_work_tree('proceed')
 
         merge_frontier = MergeFrontier.map_known_frontier(self)
 
@@ -3015,7 +3014,7 @@ def cmd_list(parser, options):
 
 def cmd_init(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
 
     if not options.name:
         parser.error(
@@ -3051,7 +3050,7 @@ def cmd_init(parser, options):
 
 def cmd_start(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
 
     if not options.name:
         parser.error(
@@ -3095,7 +3094,7 @@ def cmd_start(parser, options):
 
 def cmd_merge(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
 
     tip2 = options.tip2
 
@@ -3163,7 +3162,7 @@ def cmd_merge(parser, options):
 
 def cmd_rebase(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
 
     tip1 = options.tip1
 
@@ -3234,7 +3233,7 @@ def cmd_rebase(parser, options):
 
 def cmd_drop(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
 
     m = re.match(r'^(?P<start>.*[^\.])(?P<sep>\.{2,})(?P<end>[^\.].*)$', options.range)
     if m:
@@ -3357,7 +3356,7 @@ def cmd_drop(parser, options):
 
 def cmd_revert(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
 
     m = re.match(r'^(?P<start>.*[^\.])(?P<sep>\.{2,})(?P<end>[^\.].*)$', options.range)
     if m:
@@ -3522,7 +3521,7 @@ def cmd_record(parser, options):
 
 def cmd_autofill(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
     merge_state = read_merge_state(git, options.name)
     with TemporaryHead():
         try:
@@ -3533,7 +3532,7 @@ def cmd_autofill(parser, options):
 
 def cmd_simplify(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
     merge_state = read_merge_state(git, options.name)
     merge_frontier = MergeFrontier.map_known_frontier(merge_state)
     if not merge_frontier.is_complete():
@@ -3547,7 +3546,7 @@ def cmd_simplify(parser, options):
 
 def cmd_finish(parser, options):
     git = GitRepository()
-    require_clean_work_tree('proceed')
+    git.require_clean_work_tree('proceed')
     merge_state = read_merge_state(git, options.name, default_to_unique=False)
     merge_frontier = MergeFrontier.map_known_frontier(merge_state)
     if not merge_frontier.is_complete():

--- a/git-imerge
+++ b/git-imerge
@@ -301,6 +301,31 @@ class GitRepository(object):
         except CalledProcessError:
             return None
 
+    def check_imerge_exists(self, name):
+        """Verify that a MergeState with the given name exists.
+
+        Just check for the existence, readability, and compatible
+        version of the 'state' reference.  If the reference doesn't
+        exist, just return False.  If it exists but is unusable for
+        some other reason, raise an exception."""
+
+        try:
+            call_silently(
+                ['git', 'check-ref-format', 'refs/imerge/%s' % (name,)]
+                )
+        except CalledProcessError:
+            raise Failure('Name %r is not a valid refname component!' % (name,))
+
+        state_refname = 'refs/imerge/%s/state' % (name,)
+        for line in check_output(['git', 'for-each-ref', state_refname]).splitlines():
+            (sha1, type, refname) = line.split()
+            if refname == state_refname and type == 'blob':
+                MergeState._read_state(name, sha1)
+                # If that didn't throw an exception:
+                return True
+        else:
+            return False
+
 
 def get_default_edit():
     """Should '--edit' be used when committing intermediate user merges?
@@ -2110,32 +2135,6 @@ class MergeState(Block):
         return state
 
     @staticmethod
-    def check_exists(name):
-        """Verify that a MergeState with the given name exists.
-
-        Just check for the existence, readability, and compatible
-        version of the 'state' reference.  If the reference doesn't
-        exist, just return False.  If it exists but is unusable for
-        some other reason, raise an exception."""
-
-        try:
-            call_silently(
-                ['git', 'check-ref-format', 'refs/imerge/%s' % (name,)]
-                )
-        except CalledProcessError:
-            raise Failure('Name %r is not a valid refname component!' % (name,))
-
-        state_refname = 'refs/imerge/%s/state' % (name,)
-        for line in check_output(['git', 'for-each-ref', state_refname]).splitlines():
-            (sha1, type, refname) = line.split()
-            if refname == state_refname and type == 'blob':
-                MergeState._read_state(name, sha1)
-                # If that didn't throw an exception:
-                return True
-        else:
-            return False
-
-    @staticmethod
     def _check_no_merges(commits):
         multiparent_commits = [
             commit
@@ -2974,7 +2973,7 @@ def incorporate_user_merge(merge_state, edit_log_msg=None):
 def choose_merge_name(git, name, default_to_unique=True):
     # If a name was specified, try to use it and fail if not possible:
     if name is not None:
-        if not MergeState.check_exists(name):
+        if not git.check_imerge_exists(name):
             raise Failure('There is no incremental merge called \'%s\'!' % (name,))
         git.set_default_imerge_name(name)
         return name
@@ -2982,7 +2981,7 @@ def choose_merge_name(git, name, default_to_unique=True):
     # A name was not specified.  Try to use the default name:
     default_name = git.get_default_imerge_name()
     if default_name:
-        if MergeState.check_exists(default_name):
+        if git.check_imerge_exists(default_name):
             return default_name
         else:
             # There's no reason to keep the invalid default around:
@@ -2997,7 +2996,7 @@ def choose_merge_name(git, name, default_to_unique=True):
     if default_to_unique:
         # If there is exactly one imerge, set it to be the default and use it.
         names = list(git.iter_existing_imerge_names())
-        if len(names) == 1 and MergeState.check_exists(names[0]):
+        if len(names) == 1 and git.check_imerge_exists(names[0]):
             git.set_default_imerge_name(names[0])
             return names[0]
 

--- a/git-imerge
+++ b/git-imerge
@@ -654,12 +654,32 @@ class GitRepository(object):
             new_commit = commit_tree(
                 tree, parents,
                 msg=self.get_log_message(metadata),
-                metadata=get_author_info(metadata),
+                metadata=self.get_author_info(metadata),
                 )
             parents = [new_commit]
 
         [commit] = parents
         return commit
+
+    def get_author_info(self, commit):
+        """Return environment settings to set author metadata.
+
+        Return a map {str : str}."""
+
+        # We use newlines as separators here because msysgit has problems
+        # with NUL characters; see
+        #
+        #     https://github.com/mhagger/git-imerge/pull/71
+        a = check_output([
+            'git', '--no-pager', 'log', '-n1',
+            '--format=%an%n%ae%n%ai', commit
+            ]).strip().splitlines()
+
+        return {
+            'GIT_AUTHOR_NAME': env_encode(a[0]),
+            'GIT_AUTHOR_EMAIL': env_encode(a[1]),
+            'GIT_AUTHOR_DATE': env_encode(a[2]),
+            }
 
     def get_log_message(self, commit):
         contents = check_output([
@@ -757,27 +777,6 @@ def checkout(refname, quiet=False):
         target = '%s^0' % (refname,)
     cmd += [target]
     check_call(cmd)
-
-
-def get_author_info(commit):
-    """Return environment settings to set author metadata.
-
-    Return a map {str : str}."""
-
-    # We use newlines as separators here because msysgit has problems
-    # with NUL characters; see
-    #
-    #     https://github.com/mhagger/git-imerge/pull/71
-    a = check_output([
-        'git', '--no-pager', 'log', '-n1',
-        '--format=%an%n%ae%n%ai', commit
-        ]).strip().splitlines()
-
-    return {
-        'GIT_AUTHOR_NAME': env_encode(a[0]),
-        'GIT_AUTHOR_EMAIL': env_encode(a[1]),
-        'GIT_AUTHOR_DATE': env_encode(a[2]),
-        }
 
 
 def commit_tree(tree, parents, msg, metadata=None):

--- a/git-imerge
+++ b/git-imerge
@@ -270,6 +270,10 @@ class AutomaticMergeFailed(Exception):
         self.commit1, self.commit2 = commit1, commit2
 
 
+class InvalidBranchNameError(Failure):
+    pass
+
+
 class GitRepository(object):
     MERGE_STATE_REFNAME_RE = re.compile(
         r"""
@@ -373,6 +377,16 @@ class GitRepository(object):
             return False
         except CalledProcessError:
             return True
+
+    def check_branch_name_format(self, name):
+        """Check that name is a valid branch name."""
+
+        try:
+            call_silently(
+                ['git', 'check-ref-format', 'refs/heads/%s' % (name,)]
+                )
+        except CalledProcessError:
+            raise InvalidBranchNameError('Name %r is not a valid branch name!' % (name,))
 
     def refresh_index(self):
         process = subprocess.Popen(
@@ -602,21 +616,6 @@ class GitRepository(object):
 
         [commit] = parents
         return commit
-
-
-class InvalidBranchNameError(Failure):
-    pass
-
-
-def check_branch_name_format(name):
-    """Check that name is a valid branch name."""
-
-    try:
-        call_silently(
-            ['git', 'check-ref-format', 'refs/heads/%s' % (name,)]
-            )
-    except CalledProcessError:
-        raise InvalidBranchNameError('Name %r is not a valid branch name!' % (name,))
 
 
 def rev_parse(arg):
@@ -2243,7 +2242,7 @@ class MergeState(Block):
 
         git.check_imerge_name_format(name)
         if branch:
-            check_branch_name_format(branch)
+            git.check_branch_name_format(branch)
         else:
             branch = name
 
@@ -3112,7 +3111,7 @@ def cmd_merge(parser, options):
         if not options.branch:
             # See if we can store the result to the checked-out branch:
             try:
-                check_branch_name_format(tip1)
+                git.check_branch_name_format(tip1)
             except InvalidBranchNameError:
                 pass
             else:
@@ -3173,7 +3172,7 @@ def cmd_rebase(parser, options):
         if not options.branch:
             # See if we can store the result to the current branch:
             try:
-                check_branch_name_format(tip2)
+                git.check_branch_name_format(tip2)
             except InvalidBranchNameError:
                 pass
             else:
@@ -3282,7 +3281,7 @@ def cmd_drop(parser, options):
         if not options.branch:
             # See if we can store the result to the current branch:
             try:
-                check_branch_name_format(tip1)
+                git.check_branch_name_format(tip1)
             except InvalidBranchNameError:
                 pass
             else:
@@ -3400,7 +3399,7 @@ def cmd_revert(parser, options):
         if not options.branch:
             # See if we can store the result to the current branch:
             try:
-                check_branch_name_format(tip1)
+                git.check_branch_name_format(tip1)
             except InvalidBranchNameError:
                 pass
             else:

--- a/git-imerge
+++ b/git-imerge
@@ -436,7 +436,7 @@ class GitRepository(object):
         If not, raise ValueError."""
 
         try:
-            return rev_parse('%s^{commit}' % (arg,))
+            return self.rev_parse('%s^{commit}' % (arg,))
         except CalledProcessError:
             raise ValueError('%r does not refer to a valid git commit' % (arg,))
 
@@ -669,6 +669,9 @@ class GitRepository(object):
         [commit] = parents
         return commit
 
+    def rev_parse(self, arg):
+        return check_output(['git', 'rev-parse', '--verify', '--quiet', arg]).strip()
+
     def rev_list(self, *args):
         cmd = ['git', 'rev-list'] + list(args)
         return [
@@ -721,7 +724,7 @@ class GitRepository(object):
             ).strip().split()
 
     def get_tree(self, arg):
-        return rev_parse('%s^{tree}' % (arg,))
+        return self.rev_parse('%s^{tree}' % (arg,))
 
     def linear_ancestry(self, commit1, commit2, first_parent):
         """Compute a linear ancestry between commit1 and commit2.
@@ -751,8 +754,8 @@ class GitRepository(object):
 
         """
 
-        oid1 = rev_parse(commit1)
-        oid2 = rev_parse(commit2)
+        oid1 = self.rev_parse(commit1)
+        oid2 = self.rev_parse(commit2)
 
         parentage = {oid1 : []}
         for (commit, parents) in self.rev_list_with_parents(
@@ -847,10 +850,6 @@ class GitRepository(object):
         """
 
         return GitTemporaryHead(self, message)
-
-
-def rev_parse(arg):
-    return check_output(['git', 'rev-parse', '--verify', '--quiet', arg]).strip()
 
 
 BRANCH_PREFIX = 'refs/heads/'
@@ -3178,7 +3177,7 @@ def cmd_rebase(parser, options):
             options.name = tip2
 
     except CalledProcessError:
-        tip2 = rev_parse('HEAD')
+        tip2 = git.rev_parse('HEAD')
 
     if not options.name:
         parser.error(
@@ -3237,11 +3236,11 @@ def cmd_drop(parser, options):
                 'Range must either be a single commit '
                 'or in the form "commit..commit"'
                 )
-        start = rev_parse(m.group('start'))
-        end = rev_parse(m.group('end'))
+        start = git.rev_parse(m.group('start'))
+        end = git.rev_parse(m.group('end'))
     else:
-        end = rev_parse(options.range)
-        start = rev_parse('%s^' % (end,))
+        end = git.rev_parse(options.range)
+        start = git.rev_parse('%s^' % (end,))
 
     try:
         to_drop = git.linear_ancestry(start, end, options.first_parent)
@@ -3287,7 +3286,7 @@ def cmd_drop(parser, options):
             options.name = tip1
 
     except CalledProcessError:
-        tip1 = rev_parse('HEAD')
+        tip1 = git.rev_parse('HEAD')
 
     if not options.name:
         parser.error(
@@ -3315,7 +3314,7 @@ def cmd_drop(parser, options):
         cmd += [commit]
         check_call(cmd)
 
-    tip2 = rev_parse('HEAD')
+    tip2 = git.rev_parse('HEAD')
 
     try:
         (merge_base, commits1, commits2) = git.get_boundaries(
@@ -3360,11 +3359,11 @@ def cmd_revert(parser, options):
                 'Range must either be a single commit '
                 'or in the form "commit..commit"'
                 )
-        start = rev_parse(m.group('start'))
-        end = rev_parse(m.group('end'))
+        start = git.rev_parse(m.group('start'))
+        end = git.rev_parse(m.group('end'))
     else:
-        end = rev_parse(options.range)
-        start = rev_parse('%s^' % (end,))
+        end = git.rev_parse(options.range)
+        start = git.rev_parse('%s^' % (end,))
 
     try:
         to_revert = git.linear_ancestry(start, end, options.first_parent)
@@ -3405,7 +3404,7 @@ def cmd_revert(parser, options):
             options.name = tip1
 
     except CalledProcessError:
-        tip1 = rev_parse('HEAD')
+        tip1 = git.rev_parse('HEAD')
 
     if not options.name:
         parser.error(
@@ -3433,7 +3432,7 @@ def cmd_revert(parser, options):
         cmd += [commit]
         check_call(cmd)
 
-    tip2 = rev_parse('HEAD')
+    tip2 = git.rev_parse('HEAD')
 
     try:
         (merge_base, commits1, commits2) = git.get_boundaries(

--- a/git-imerge
+++ b/git-imerge
@@ -341,6 +341,12 @@ class GitRepository(object):
         else:
             return False
 
+    def read_imerge_state_dict(self, name):
+        state_string = check_output(
+            ['git', 'cat-file', 'blob', 'refs/imerge/%s/state' % (name,)],
+            )
+        return json.loads(state_string)
+
 
 def get_default_edit():
     """Should '--edit' be used when committing intermediate user merges?
@@ -2126,10 +2132,7 @@ class MergeState(Block):
 
     @staticmethod
     def _read_state(git, name):
-        state_string = check_output(
-            ['git', 'cat-file', 'blob', 'refs/imerge/%s/state' % (name,)],
-            )
-        state = json.loads(state_string)
+        state = git.read_imerge_state_dict(name)
 
         version = tuple(int(i) for i in state['version'].split('.'))
         if version[0] != STATE_VERSION[0] or version[1] > STATE_VERSION[1]:

--- a/git-imerge
+++ b/git-imerge
@@ -1032,6 +1032,15 @@ class GitRepository(object):
 
         return out.strip()
 
+    def revert(self, commit):
+        """Apply the inverse of commit^..commit to HEAD and commit."""
+
+        cmd = ['git', 'revert', '--no-edit']
+        if len(self.get_commit_parents(commit)) > 1:
+            cmd += ['-m', '1']
+        cmd += [commit]
+        check_call(cmd)
+
     def reparent(self, commit, parent_sha1s, msg=None):
         """Create a new commit object like commit, but with the specified parents.
 
@@ -3314,11 +3323,7 @@ def cmd_drop(parser, options):
 
     git.checkout(end)
     for commit in reversed(to_drop):
-        cmd = ['git', 'revert', '--no-edit']
-        if len(git.get_commit_parents(commit)) > 1:
-            cmd += ['-m', '1']
-        cmd += [commit]
-        check_call(cmd)
+        git.revert(commit)
 
     tip2 = git.rev_parse('HEAD')
 
@@ -3429,11 +3434,7 @@ def cmd_revert(parser, options):
 
     git.checkout(end)
     for commit in reversed(to_revert):
-        cmd = ['git', 'revert', '--no-edit']
-        if len(git.get_commit_parents(commit)) > 1:
-            cmd += ['-m', '1']
-        cmd += [commit]
-        check_call(cmd)
+        git.revert(commit)
 
     tip2 = git.rev_parse('HEAD')
 

--- a/git-imerge
+++ b/git-imerge
@@ -805,6 +805,11 @@ class GitRepository(object):
             commits = line.strip().split()
             yield (commits[0], commits[1:])
 
+    def summarize_commit(self, commit):
+        """Summarize `commit` to stdout."""
+
+        check_call(['git', '--no-pager', 'log', '--no-walk', commit])
+
     def get_author_info(self, commit):
         """Return environment settings to set author metadata.
 
@@ -2638,12 +2643,12 @@ class MergeState(Block):
             '\n'
             'Original first commit:\n'
             )
-        check_call(['git', '--no-pager', 'log', '--no-walk', self[i1, 0].sha1])
+        self.git.summarize_commit(self[i1, 0].sha1)
         sys.stderr.write(
             '\n'
             'Original second commit:\n'
             )
-        check_call(['git', '--no-pager', 'log', '--no-walk', self[0, i2].sha1])
+        self.git.summarize_commit(self[0, i2].sha1)
         sys.stderr.write(
             '\n'
             'There was a conflict merging commit %d-%d, shown above.\n'

--- a/git-imerge
+++ b/git-imerge
@@ -347,6 +347,22 @@ class GitRepository(object):
             )
         return json.loads(state_string)
 
+    def is_ff(self, refname, commit):
+        """Would updating refname to commit be a fast-forward update?
+
+        Return True iff refname is not currently set or it points to an
+        ancestor of commit.
+
+        """
+
+        try:
+            ref_oldval = get_commit_sha1(refname)
+        except ValueError:
+            # refname doesn't already exist; no problem.
+            return True
+        else:
+            return MergeState._is_ancestor(ref_oldval, commit)
+
 
 def get_default_edit():
     """Should '--edit' be used when committing intermediate user merges?
@@ -757,23 +773,6 @@ class TemporaryHead(object):
                     )
 
         return False
-
-
-def is_ff(refname, commit):
-    """Would updating refname to commit be a fast-forward update?
-
-    Return True iff refname is not currently set or it points to an
-    ancestor of commit.
-
-    """
-
-    try:
-        ref_oldval = get_commit_sha1(refname)
-    except ValueError:
-        # refname doesn't already exist; no problem.
-        return True
-    else:
-        return MergeState._is_ancestor(ref_oldval, commit)
 
 
 def reparent(commit, parent_sha1s, msg=None):
@@ -2627,7 +2626,7 @@ class MergeState(Block):
         else:
             apex = base_sha1
 
-        if not force and not is_ff(refname, apex):
+        if not force and not self.git.is_ff(refname, apex):
             raise Failure(
                 '%s cannot be updated to %s without discarding history.\n'
                 'Use --force if you are sure, or choose a different reference'

--- a/git-imerge
+++ b/git-imerge
@@ -650,7 +650,7 @@ class GitRepository(object):
 
             # Create a commit, copying the old log message and author info
             # from the metadata commit:
-            tree = get_tree(commit)
+            tree = self.get_tree(commit)
             new_commit = self.commit_tree(
                 tree, parents,
                 msg=self.get_log_message(metadata),
@@ -696,6 +696,9 @@ class GitRepository(object):
         return check_output(
             ['git', '--no-pager', 'log', '--no-walk', '--pretty=format:%P', commit]
             ).strip().split()
+
+    def get_tree(self, arg):
+        return rev_parse('%s^{tree}' % (arg,))
 
     def get_boundaries(self, tip1, tip2, first_parent):
         """Get the boundaries of an incremental merge.
@@ -790,10 +793,6 @@ def git_dir():
             ['git', 'rev-parse', '--git-dir']
             ).rstrip('\n')
     return git_dir_cache
-
-
-def get_tree(arg):
-    return rev_parse('%s^{tree}' % (arg,))
 
 
 BRANCH_PREFIX = 'refs/heads/'
@@ -1960,7 +1959,7 @@ class Block(object):
                 msg='Autofilling %d-%d (second way)...',
                 record=False,
                 )
-            if get_tree(vertex_v1) == get_tree(vertex_v2):
+            if self.git.get_tree(vertex_v1) == self.git.get_tree(vertex_v2):
                 sys.stderr.write(
                     'The two ways of autofilling %d-%d agree.\n'
                     % self.get_original_indexes(i1, i2)
@@ -2800,7 +2799,7 @@ class MergeState(Block):
         commit = self[i1, 0].sha1
         for i2 in range(1, self.len2):
             orig = self[0, i2].sha1
-            tree = get_tree(self[i1, i2].sha1)
+            tree = self.git.get_tree(self[i1, i2].sha1)
 
             # Create a commit, copying the old log message:
             msg = (
@@ -2902,7 +2901,7 @@ class MergeState(Block):
                 'Cannot simplify to merge because merge %d-%d is not yet done'
                 % (self.len1 - 1, self.len2 - 1)
                 )
-        tree = get_tree(self[-1, -1].sha1)
+        tree = self.git.get_tree(self[-1, -1].sha1)
         parents = [self[-1, 0].sha1, self[0, -1].sha1]
 
         # Create a preliminary commit with a generic commit message:

--- a/git-imerge
+++ b/git-imerge
@@ -906,6 +906,54 @@ class GitRepository(object):
 
         return out.strip()
 
+    def reparent(self, commit, parent_sha1s, msg=None):
+        """Create a new commit object like commit, but with the specified parents.
+
+        commit is the SHA1 of an existing commit and parent_sha1s is a
+        list of SHA1s.  Create a new commit exactly like that one, except
+        that it has the specified parent commits.  Return the SHA1 of the
+        resulting commit object, which is already stored in the object
+        database but is not yet referenced by anything.
+
+        If msg is set, then use it as the commit message for the new
+        commit."""
+
+        old_commit = check_output(['git', 'cat-file', 'commit', commit])
+        separator = old_commit.index('\n\n')
+        headers = old_commit[:separator + 1].splitlines(True)
+        rest = old_commit[separator + 2:]
+
+        new_commit = StringIO()
+        for i in range(len(headers)):
+            line = headers[i]
+            if line.startswith('tree '):
+                new_commit.write(line)
+                for parent_sha1 in parent_sha1s:
+                    new_commit.write('parent %s\n' % (parent_sha1,))
+            elif line.startswith('parent '):
+                # Discard old parents:
+                pass
+            else:
+                new_commit.write(line)
+
+        new_commit.write('\n')
+        if msg is None:
+            new_commit.write(rest)
+        else:
+            new_commit.write(msg)
+            if not msg.endswith('\n'):
+                new_commit.write('\n')
+
+        process = subprocess.Popen(
+            ['git', 'hash-object', '-t', 'commit', '-w', '--stdin'],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            )
+        out = communicate(process, input=new_commit.getvalue())[0]
+        retcode = process.poll()
+        if retcode:
+            raise Failure('Could not reparent commit %s' % (commit,))
+        return out.strip()
+
     def temporary_head(self, message):
         """Return a context manager to manage a temporary HEAD.
 
@@ -915,55 +963,6 @@ class GitRepository(object):
         """
 
         return GitTemporaryHead(self, message)
-
-
-def reparent(commit, parent_sha1s, msg=None):
-    """Create a new commit object like commit, but with the specified parents.
-
-    commit is the SHA1 of an existing commit and parent_sha1s is a
-    list of SHA1s.  Create a new commit exactly like that one, except
-    that it has the specified parent commits.  Return the SHA1 of the
-    resulting commit object, which is already stored in the object
-    database but is not yet referenced by anything.
-
-    If msg is set, then use it as the commit message for the new
-    commit."""
-
-    old_commit = check_output(['git', 'cat-file', 'commit', commit])
-    separator = old_commit.index('\n\n')
-    headers = old_commit[:separator + 1].splitlines(True)
-    rest = old_commit[separator + 2:]
-
-    new_commit = StringIO()
-    for i in range(len(headers)):
-        line = headers[i]
-        if line.startswith('tree '):
-            new_commit.write(line)
-            for parent_sha1 in parent_sha1s:
-                new_commit.write('parent %s\n' % (parent_sha1,))
-        elif line.startswith('parent '):
-            # Discard old parents:
-            pass
-        else:
-            new_commit.write(line)
-
-    new_commit.write('\n')
-    if msg is None:
-        new_commit.write(rest)
-    else:
-        new_commit.write(msg)
-        if not msg.endswith('\n'):
-            new_commit.write('\n')
-
-    process = subprocess.Popen(
-        ['git', 'hash-object', '-t', 'commit', '-w', '--stdin'],
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-        )
-    out = communicate(process, input=new_commit.getvalue())[0]
-    retcode = process.poll()
-    if retcode:
-        raise Failure('Could not reparent commit %s' % (commit,))
-    return out.strip()
 
 
 class MergeRecord(object):
@@ -1955,7 +1954,9 @@ class Block(object):
                     )
                 # Everything is OK.  Now reparent the actual vertex merge to
                 # have above and left as its parents:
-                merges.append((i1, i2, reparent(vertex_v1, [above, left])))
+                merges.append(
+                    (i1, i2, self.git.reparent(vertex_v1, [above, left]))
+                    )
             else:
                 sys.stderr.write(
                     'The two ways of autofilling %d-%d do not agree.  Backtracking...\n'
@@ -2616,7 +2617,7 @@ class MergeState(Block):
                 )
         if swapped:
             # Create a new merge with the parents in the conventional order:
-            commit = reparent(commit, [parents[1], parents[0]])
+            commit = self.git.reparent(commit, [parents[1], parents[0]])
 
         i1, i2 = i1first, i2second
         self[i1, i2].record_merge(commit, MergeRecord.NEW_MANUAL)
@@ -3599,7 +3600,7 @@ def cmd_reparent(parser, options):
     except ValueError as e:
         sys.exit(e.message)
 
-    sys.stdout.write('%s\n' % (reparent(commit_sha1, parent_sha1s),))
+    sys.stdout.write('%s\n' % (git.reparent(commit_sha1, parent_sha1s),))
 
 
 def main(args):


### PR DESCRIPTION
Instead of running Git commands directly, from all over the place, add a new class `GitRepository` that is responsible for all interactions with the repository. This opens up two possibilities:

* If somebody wants a version of `git-imerge` that uses libgit2 instead of spawning subprocesses all of the time, they could do it by implementing a second class like `GitRepository`. (In fact, the class could selectively implement the easy/frequent operations using `libgit2`, calling out to Git for the others.)

* The class could be stubbed for testing purposes.

I'm not at all happy with the breadth and complexity of this interface. More work here could probably make it more wieldy.
