### PR TITLE
Avoid storing the default merge to the Git configuration

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -3017,11 +3017,15 @@ class MergeState(Block):
 
 
 def choose_merge_name(git, name):
+    names = list(git.iter_existing_imerge_names())
+
     # If a name was specified, try to use it and fail if not possible:
     if name is not None:
-        if not git.check_imerge_exists(name):
+        if name not in names:
             raise Failure('There is no incremental merge called \'%s\'!' % (name,))
-        git.set_default_imerge_name(name)
+        if len(names) > 1:
+            # Record this as the new default:
+            git.set_default_imerge_name(name)
         return name
 
     # A name was not specified.  Try to use the default name:
@@ -3040,7 +3044,6 @@ def choose_merge_name(git, name):
                 )
 
     # If there is exactly one imerge, set it to be the default and use it.
-    names = list(git.iter_existing_imerge_names())
     if len(names) == 1 and git.check_imerge_exists(names[0]):
         return names[0]
 
@@ -3053,8 +3056,11 @@ def read_merge_state(git, name=None):
 
 def cmd_list(parser, options):
     git = GitRepository()
+    names = list(git.iter_existing_imerge_names())
     default_merge = git.get_default_imerge_name()
-    for name in git.iter_existing_imerge_names():
+    if not default_merge and len(names) == 1:
+        default_merge = names[0]
+    for name in names:
         if name == default_merge:
             sys.stdout.write('* %s\n' % (name,))
         else:
@@ -3089,7 +3095,8 @@ def cmd_init(parser, options):
         branch=(options.branch or options.name),
         )
     merge_state.save()
-    git.set_default_imerge_name(options.name)
+    if len(list(git.iter_existing_imerge_names())) > 1:
+        git.set_default_imerge_name(options.name)
 
 
 def cmd_start(parser, options):
@@ -3121,7 +3128,8 @@ def cmd_start(parser, options):
         branch=(options.branch or options.name),
         )
     merge_state.save()
-    git.set_default_imerge_name(options.name)
+    if len(list(git.iter_existing_imerge_names())) > 1:
+        git.set_default_imerge_name(options.name)
 
     try:
         merge_state.auto_complete_frontier()
@@ -3187,7 +3195,8 @@ def cmd_merge(parser, options):
         branch=options.branch,
         )
     merge_state.save()
-    git.set_default_imerge_name(name)
+    if len(list(git.iter_existing_imerge_names())) > 1:
+        git.set_default_imerge_name(name)
 
     try:
         merge_state.auto_complete_frontier()
@@ -3255,7 +3264,8 @@ def cmd_rebase(parser, options):
         branch=options.branch,
         )
     merge_state.save()
-    git.set_default_imerge_name(options.name)
+    if len(list(git.iter_existing_imerge_names())) > 1:
+        git.set_default_imerge_name(options.name)
 
     try:
         merge_state.auto_complete_frontier()
@@ -3371,7 +3381,8 @@ def cmd_drop(parser, options):
         branch=options.branch,
         )
     merge_state.save()
-    git.set_default_imerge_name(options.name)
+    if len(list(git.iter_existing_imerge_names())) > 1:
+        git.set_default_imerge_name(options.name)
 
     try:
         merge_state.auto_complete_frontier()
@@ -3482,7 +3493,8 @@ def cmd_revert(parser, options):
         branch=options.branch,
         )
     merge_state.save()
-    git.set_default_imerge_name(options.name)
+    if len(list(git.iter_existing_imerge_names())) > 1:
+        git.set_default_imerge_name(options.name)
 
     try:
         merge_state.auto_complete_frontier()

--- a/git-imerge
+++ b/git-imerge
@@ -401,7 +401,7 @@ class GitRepository(object):
             check_call(['git', 'config', 'imerge.default', name])
 
     def get_default_imerge_name(self):
-        """Get the name of the default merge, or None if none is currently set."""
+        """Get the name of the default merge, or None if it is currently unset."""
 
         try:
             return check_output(['git', 'config', 'imerge.default']).rstrip()
@@ -3016,7 +3016,7 @@ class MergeState(Block):
             )
 
 
-def choose_merge_name(git, name, default_to_unique=True):
+def choose_merge_name(git, name):
     # If a name was specified, try to use it and fail if not possible:
     if name is not None:
         if not git.check_imerge_exists(name):
@@ -3039,21 +3039,17 @@ def choose_merge_name(git, name, default_to_unique=True):
                 % (default_name,)
                 )
 
-    if default_to_unique:
-        # If there is exactly one imerge, set it to be the default and use it.
-        names = list(git.iter_existing_imerge_names())
-        if len(names) == 1 and git.check_imerge_exists(names[0]):
-            git.set_default_imerge_name(names[0])
-            return names[0]
+    # If there is exactly one imerge, set it to be the default and use it.
+    names = list(git.iter_existing_imerge_names())
+    if len(names) == 1 and git.check_imerge_exists(names[0]):
+        git.set_default_imerge_name(names[0])
+        return names[0]
 
     raise Failure('Please select an incremental merge using --name')
 
 
-def read_merge_state(git, name=None, default_to_unique=True):
-    return MergeState.read(
-        git,
-        choose_merge_name(git, name, default_to_unique=default_to_unique),
-        )
+def read_merge_state(git, name=None):
+    return MergeState.read(git, choose_merge_name(git, name))
 
 
 def cmd_list(parser, options):
@@ -3499,9 +3495,7 @@ def cmd_revert(parser, options):
 
 def cmd_remove(parser, options):
     git = GitRepository()
-    MergeState.remove(
-        git, choose_merge_name(git, options.name, default_to_unique=False),
-        )
+    MergeState.remove(git, choose_merge_name(git, options.name))
 
 
 def cmd_continue(parser, options):
@@ -3572,7 +3566,7 @@ def cmd_simplify(parser, options):
 def cmd_finish(parser, options):
     git = GitRepository()
     git.require_clean_work_tree('proceed')
-    merge_state = read_merge_state(git, options.name, default_to_unique=False)
+    merge_state = read_merge_state(git, options.name)
     merge_frontier = MergeFrontier.map_known_frontier(merge_state)
     if not merge_frontier.is_complete():
         raise Failure('Merge %s is not yet complete!' % (merge_state.name,))

--- a/git-imerge
+++ b/git-imerge
@@ -3035,14 +3035,13 @@ def choose_merge_name(git, name):
             raise Failure(
                 'Warning: The default incremental merge \'%s\' has disappeared.\n'
                 '(The setting imerge.default has been cleared.)\n'
-                'Please select an incremental merge using --name'
+                'Please try again.'
                 % (default_name,)
                 )
 
     # If there is exactly one imerge, set it to be the default and use it.
     names = list(git.iter_existing_imerge_names())
     if len(names) == 1 and git.check_imerge_exists(names[0]):
-        git.set_default_imerge_name(names[0])
         return names[0]
 
     raise Failure('Please select an incremental merge using --name')


### PR DESCRIPTION
Partly motivated by Git's untidiness when it comes to removing config sections, this PR changes `git-imerge` to avoid writing `imerge.default` to the Git configuration if there is only a single imerge in progress.

Fixes #77.
