### PR TITLE
Add a --preserve-author option to finish

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -2838,7 +2838,8 @@ class MergeState(Block):
 
         self._set_refname(refname, self[-1, -1].sha1, force=force)
 
-    def simplify_to_rebase_with_history(self, refname, force=False):
+    def simplify_to_rebase_with_history(self, refname, force=False,
+                                        preserve_author=False):
         i1 = self.len1 - 1
         for i2 in range(1, self.len2):
             if not (i1, i2) in self:
@@ -2858,8 +2859,10 @@ class MergeState(Block):
                 self.git.get_log_message(orig).rstrip('\n')
                 + '\n\n(rebased-with-history from commit %s)\n' % orig
                 )
-            commit = self.git.commit_tree(tree, [commit, orig], msg=msg)
-
+            kwargs = dict(tree=tree, parents=[commit, orig], msg=msg)
+            if (preserve_author):
+                kwargs['metadata']=self.git.get_author_info(orig)
+            commit = self.git.commit_tree(**kwargs)
         self._set_refname(refname, commit, force=force)
 
     def _simplify_to_path(self, refname, base, path, force=False):
@@ -2967,7 +2970,7 @@ class MergeState(Block):
         # Now let the user edit the commit log message:
         self.git.amend()
 
-    def simplify(self, refname, force=False):
+    def simplify(self, refname, force=False, preserve_author=False):
         """Simplify this MergeState and save the result to refname.
 
         The merge must be complete before calling this method."""
@@ -2975,7 +2978,8 @@ class MergeState(Block):
         if self.goal == 'full':
             self.simplify_to_full(refname, force=force)
         elif self.goal == 'rebase-with-history':
-            self.simplify_to_rebase_with_history(refname, force=force)
+            self.simplify_to_rebase_with_history(refname, force=force,
+                                                 preserve_author=preserve_author)
         elif self.goal == 'rebase':
             self.simplify_to_rebase(refname, force=force)
         elif self.goal == 'drop':
@@ -3580,7 +3584,8 @@ def cmd_finish(parser, options):
     if options.goal is not None:
         merge_state.set_goal(options.goal)
         merge_state.save()
-    merge_state.simplify(refname, force=options.force)
+    merge_state.simplify(refname, force=options.force,
+                         preserve_author=options.preserve_author)
     MergeState.remove(git, merge_state.name)
 
 
@@ -3823,6 +3828,11 @@ def main(args):
         '--force',
         action='store_true', default=False,
         help='allow the target branch to be updated in a non-fast-forward manner',
+        )
+    subparser.add_argument(
+        '--preserve-author', dest="preserve_author",
+        action='store_true', default=False,
+        help='preserve original author information on simplify-to-rebase',
         )
 
     subparser = subparsers.add_parser(


### PR DESCRIPTION
Add a --preserve-author option to finish that will retain the original
commit author information for a rebase-with-history goal.  This makes
it more convenient to identify the true owner of the code after doing
blames, bisects and other such analyses.