### PR TITLE
Fix `autofill` command

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -282,8 +282,11 @@ class GitTemporaryHead(object):
 
     """
 
-    def __enter__(self, git, message):
+    def __init__(self, git, message):
+        self.git = git
         self.message = message
+
+    def __enter__(self):
         try:
             self.head_name = check_output(['git', 'symbolic-ref', '--quiet', 'HEAD']).strip()
         except CalledProcessError:

--- a/t/test-conflicted
+++ b/t/test-conflicted
@@ -23,7 +23,11 @@ git checkout c
 "$GIT_IMERGE" init --name=c-d d
 "$GIT_IMERGE" list
 "$GIT_IMERGE" diagram --commits --frontier --html=imerge0.html
-"$GIT_IMERGE" autofill || true
+"$GIT_IMERGE" autofill 2>&1 | tee autofill.out
+if grep -q Traceback autofill.out
+then
+    echo 'KNOWN FAILURE!'
+fi
 "$GIT_IMERGE" diagram --commits --frontier --html=imerge1.html
 "$GIT_IMERGE" continue --edit
 echo 'cd version' >conflict.txt
@@ -36,7 +40,11 @@ GIT_EDITOR=cat "$GIT_IMERGE" simplify --goal=merge --branch=c-d-merge
 "$GIT_IMERGE" remove
 
 git checkout c
-"$GIT_IMERGE" start --goal=full --first-parent --name=c-d d || true
+"$GIT_IMERGE" start --goal=full --first-parent --name=c-d d 2>&1 | tee start.out
+if grep -q Traceback start.out
+then
+    exit 1
+fi
 "$GIT_IMERGE" diagram --commits --frontier --html=imerge3.html
 echo 'cd version' >conflict.txt
 git add conflict.txt

--- a/t/test-conflicted
+++ b/t/test-conflicted
@@ -26,7 +26,7 @@ git checkout c
 "$GIT_IMERGE" autofill 2>&1 | tee autofill.out
 if grep -q Traceback autofill.out
 then
-    echo 'KNOWN FAILURE!'
+    exit 1
 fi
 "$GIT_IMERGE" diagram --commits --frontier --html=imerge1.html
 "$GIT_IMERGE" continue --edit


### PR DESCRIPTION
There was an error in `GitTemporaryHead` that wasn't noticed by the test suite because it appeared when running `git imerge autofill` in a context where it was supposed to fail. Add a test to detect the failure, and then fix the bug and merge it forward.
