### PR TITLE
Retain the original author information for a rebase-with-history goal

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -2863,8 +2863,9 @@ class MergeState(Block):
                 self.git.get_log_message(orig).rstrip('\n')
                 + '\n\n(rebased-with-history from commit %s)\n' % orig
                 )
-            commit = self.git.commit_tree(tree, [commit, orig], msg=msg)
-
+            kwargs = dict(tree=tree, parents=[commit, orig], msg=msg)
+            kwargs['metadata']=self.git.get_author_info(orig)
+            commit = self.git.commit_tree(**kwargs)
         self._set_refname(refname, commit, force=force)
 
     def simplify_to_border(


### PR DESCRIPTION
This makes it more convenient to identify the real author of the code
after doing blames, bisects and other such analysis.

This is rework of original PR: https://github.com/mhagger/git-imerge/pull/119
with changes suggested by @mhagger (i.e. don't add new option, always preserve original author)