### PR TITLE
Retain author info whenever retaining commit message

### DIFF
--- a/git-imerge
+++ b/git-imerge
@@ -2863,7 +2863,11 @@ class MergeState(Block):
                 self.git.get_log_message(orig).rstrip('\n')
                 + '\n\n(rebased-with-history from commit %s)\n' % orig
                 )
-            commit = self.git.commit_tree(tree, [commit, orig], msg=msg)
+            commit = self.git.commit_tree(
+                tree, [commit, orig],
+                msg=msg,
+                metadata=self.git.get_author_info(orig),
+            )
 
         self._set_refname(refname, commit, force=force)
 

--- a/git-imerge
+++ b/git-imerge
@@ -2913,7 +2913,11 @@ class MergeState(Block):
                     + '\n\n(rebased from commit %s)\n' % (orig,)
                     )
 
-            commit = self.git.commit_tree(tree, parents, msg=msg)
+            commit = self.git.commit_tree(
+                tree, parents,
+                msg=msg,
+                metadata=self.git.get_author_info(orig),
+            )
         commit1 = commit
 
         i2 = self.len2 - 1
@@ -2936,7 +2940,11 @@ class MergeState(Block):
                     + '\n\n(rebased from commit %s)\n' % (orig,)
                     )
 
-            commit = self.git.commit_tree(tree, parents, msg=msg)
+            commit = self.git.commit_tree(
+                tree, parents,
+                msg=msg,
+                metadata=self.git.get_author_info(orig),
+            )
         commit2 = commit
 
         # Construct the apex commit:

--- a/t/create-test-repo
+++ b/t/create-test-repo
@@ -4,6 +4,9 @@ set -e
 
 DESCRIPTION="git-imerge test repository"
 
+# Sleep between commits to give commits distinct timestamps:
+SLEEP="sleep 1"
+
 modify() {
     filename="$1"
     text="$2"
@@ -36,12 +39,14 @@ git config user.email 'luser@example.com'
 
 modify a.txt 0
 git commit -m 'm⇒0'
+$SLEEP
 
 git checkout -b a --
 for i in $(seq 8)
 do
     modify a.txt $i
     git commit -m "a⇒$i"
+    $SLEEP
 done
 
 git checkout -b b master --
@@ -49,6 +54,7 @@ for i in $(seq 5)
 do
     modify b.txt $i
     git commit -m "b⇒$i"
+    $SLEEP
 done
 
 git checkout -b c master --
@@ -56,13 +62,16 @@ for i in $(seq 3)
 do
     modify c.txt $i
     git commit -m "c⇒$i"
+    $SLEEP
 done
 modify conflict.txt "c version"
 git commit -m "c conflict"
+$SLEEP
 for i in $(seq 4 8)
 do
     modify c.txt $i
     git commit -m "c⇒$i"
+    $SLEEP
 done
 
 git checkout -b d master --
@@ -70,6 +79,7 @@ for i in $(seq 2)
 do
     modify d.txt $i
     git commit -m "d⇒$i"
+    $SLEEP
 done
 modify conflict.txt "d version"
 git commit -m "d conflict"
@@ -77,6 +87,7 @@ for i in $(seq 3 5)
 do
     modify d.txt $i
     git commit -m "d⇒$i"
+    $SLEEP
 done
 
 git checkout master --


### PR DESCRIPTION
* In #119, @greened added an option to make `rebase-with-history` retain the authorship of the rebased commits. This PR was revised (following my suggestion) by @DEVoytas into #137 to make authorship retention non-optional for `rebase-with-history`.
* In #135, @DEVoytas pointed out that `border-with-history` doesn't retain the authorship of the original commit.

I agree with those changes. In fact, I propose the following guideline: whenever we retain the commit message from a pre-existing commit (even if we append a comment to it), we should copy that commit's author information (name, email, and timestamp) to the new commit, too. My gut tells me that to do otherwise, even in a commit that is a merge that includes the original commit, would make it look like the person running imerge is taking credit for the original author's work.

That policy is implemented here. What do you think?

Fixes #135.
