### PR TITLE
Mention python3 first, python2 second

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,11 +59,11 @@ Requirements
 
 * A Python interpreter; either
 
+  * Python 3.x, version 3.3 or later.
+
   * Python 2.x, version 2.6 or later.  If you are using Python
     2.6.x, then you have to install the ``argparse`` module yourself,
     as it was only added to the standard library in Python 2.7.
-
-  * Python 3.x, version 3.3 or later.
 
 * A recent version of Git.
 

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -243,21 +243,21 @@ def communicate(process, input=None):
     return (output, error)
 
 
-if sys.hexversion < 0x03000000:
-    # In Python 2.x, os.environ keys and values must be byte
-    # strings:
-    def env_encode(s):
-        """Encode unicode keys or values for use in os.environ."""
-
-        return s.encode(PREFERRED_ENCODING)
-
-else:
+if sys.hexversion >= 0x03000000:
     # In Python 3.x, os.environ keys and values must be unicode
     # strings:
     def env_encode(s):
         """Use unicode keys or values unchanged in os.environ."""
 
         return s
+
+else:
+    # In Python 2.x, os.environ keys and values must be byte
+    # strings:
+    def env_encode(s):
+        """Encode unicode keys or values for use in os.environ."""
+
+        return s.encode(PREFERRED_ENCODING)
 
 
 class UncleanWorkTreeError(Failure):


### PR DESCRIPTION
Now that Python 2 is end-of-life, let's make Python 3 more prominent than it in the docs.
