### PR TITLE
Make the `MergeFrontier` class polymorphic

### DIFF
--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1759,12 +1759,24 @@ class BlockwiseMergeFrontier(MergeFrontier):
     def initiate_merge(block):
         """Return a BlockwiseMergeFrontier instance for block.
 
-        Compute the blocks making up the boundary using bisection. See
-        find_frontier_blocks() for more information.
+        Compute the blocks making up the boundary using bisection (see
+        find_frontier_blocks() for more information). Outline the
+        blocks, and return a BlockwiseMergeFrontier reflecting the
+        final result.
 
         """
 
-        return BlockwiseMergeFrontier(block, list(find_frontier_blocks(block)))
+        merge_frontier = BlockwiseMergeFrontier(
+            block, list(find_frontier_blocks(block)),
+            )
+
+        if merge_frontier.auto_fill():
+            # Auto-fill doesn't necessarily update its object to
+            # reflect all of the changes it might have made, so we
+            # have to generate a fresh one:
+            merge_frontier = BlockwiseMergeFrontier.map_known_frontier(block)
+
+        return merge_frontier
 
     def __init__(self, block, blocks=None):
         MergeFrontier.__init__(self, block)
@@ -2346,7 +2358,7 @@ class Block(object):
             return self.auto_fill_micromerge()
         else:
             merge_frontier = BlockwiseMergeFrontier.initiate_merge(self)
-            return merge_frontier.auto_fill()
+            return bool(merge_frontier)
 
     # The codes in the 2D array returned from create_diagram()
     MERGE_UNKNOWN = 0

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1776,7 +1776,13 @@ class BlockwiseMergeFrontier(MergeFrontier):
         return iter(self.blocks)
 
     def __bool__(self):
-        """Return True iff this frontier has no completed parts."""
+        """Return True iff this frontier contains any SubBlocks.
+
+        Return True if this BlockwiseMergeFrontier contains any
+        SubBlocks that are thought to be completely mergeable (whether
+        they have been outlined or not).
+
+        """
 
         return bool(self.blocks)
 

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -2302,20 +2302,6 @@ class Block(object):
                 sys.stderr.write('success.\n')
                 return True
 
-    def map_frontier(self):
-        """Return a MergeFrontier instance describing the current frontier.
-
-        """
-
-        merge_state = self.get_merge_state()
-        if merge_state.manual:
-            # FIXME:
-            return BlockwiseMergeFrontier.map_known_frontier(self)
-        elif merge_state.goal == 'full':
-            return FullMergeFrontier.map_known_frontier(self)
-        else:
-            return BlockwiseMergeFrontier.map_known_frontier(self)
-
     def auto_outline(self):
         """Complete the outline of this Block.
 
@@ -2805,6 +2791,19 @@ class MergeState(Block):
         (i1, i2) = self._normalize_indexes(index)
         value = self._data[i1][i2]
         return (value is not None) and value.is_known()
+
+    def map_frontier(self):
+        """Return a MergeFrontier instance describing the current frontier.
+
+        """
+
+        if self.manual:
+            # FIXME:
+            return BlockwiseMergeFrontier.map_known_frontier(self)
+        elif self.goal == 'full':
+            return FullMergeFrontier.map_known_frontier(self)
+        else:
+            return BlockwiseMergeFrontier.map_known_frontier(self)
 
     def auto_complete_frontier(self):
         """Complete the frontier using automerges.

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1952,9 +1952,13 @@ class BlockwiseMergeFrontier(MergeFrontier):
         unblocked_block[1, 1].record_blocked(False)
 
     def auto_fill(self):
-        """Try to outline this merge frontier.
+        """Outline this merge frontier to the extent possible.
 
-        Return True iff some progress was made."""
+        Return True iff some progress was made. This method does *not*
+        keep self up to date on any progress; if it returns
+        successfully, you should recompute the frontier from scratch.
+
+        """
 
         while self:
             best_block = min(self, key=lambda block: (block.len1, block.len2))

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1854,10 +1854,10 @@ class BlockwiseMergeFrontier(MergeFrontier):
             self.blocks = self._normalized_blocks(newblocks)
 
     def partition(self, block):
-        """Return two BlockwiseMergeFrontier instances partitioned by block.
+        """Iterate over the BlockwiseMergeFrontiers partitioned by block.
 
-        Return (frontier1, frontier2), where each frontier is limited
-        to each side of the argument.
+        Iterate over the zero, one, or two BlockwiseMergeFrontiers to
+        the left and/or right of block.
 
         block must be contained in this frontier and already be
         outlined.
@@ -1882,10 +1882,12 @@ class BlockwiseMergeFrontier(MergeFrontier):
                 raise ValueError(
                     'BlockwiseMergeFrontier partitioned with inappropriate block'
                     )
-        return (
-            BlockwiseMergeFrontier(self.block[:block.len1, block.len2 - 1:], left),
-            BlockwiseMergeFrontier(self.block[block.len1 - 1:, :block.len2], right),
-            )
+
+        if block.len2 < self.block.len2:
+            yield BlockwiseMergeFrontier(self.block[:block.len1, block.len2 - 1:], left)
+
+        if block.len1 < self.block.len1:
+            yield BlockwiseMergeFrontier(self.block[block.len1 - 1:, :block.len2], right)
 
     def iter_boundary_blocks(self):
         """Iterate over the complete blocks that form this block's boundary.
@@ -1971,11 +1973,10 @@ class BlockwiseMergeFrontier(MergeFrontier):
 
                 # Continue looping...
             else:
-                f1, f2 = self.partition(best_block)
-                if f1:
-                    f1.auto_fill()
-                if f2:
-                    f2.auto_fill()
+                for f in self.partition(best_block):
+                    if f:
+                        f.auto_fill()
+
                 return True
 
         return False

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -2223,11 +2223,12 @@ class Block(object):
                 )
             try:
                 self.git.automerge(self[i1, 0].sha1, self[0, i2].sha1)
-                sys.stderr.write('success.\n')
-                return True
             except AutomaticMergeFailed:
                 sys.stderr.write('failure.\n')
                 return False
+            else:
+                sys.stderr.write('success.\n')
+                return True
 
     def map_frontier(self):
         """Return a MergeFrontier instance describing the current frontier.
@@ -2253,10 +2254,12 @@ class Block(object):
             logmsg = 'imerge \'%s\': automatic merge %d-%d' % (self.name, i1orig, i2orig)
             try:
                 merge = self.git.automerge(commit1, commit2, msg=logmsg)
-                sys.stderr.write('success.\n')
             except AutomaticMergeFailed as e:
                 sys.stderr.write('unexpected conflict.  Backtracking...\n')
                 raise UnexpectedMergeFailure(str(e), i1, i2)
+            else:
+                sys.stderr.write('success.\n')
+
             if record:
                 merges.append((i1, i2, merge))
             return merge
@@ -2334,12 +2337,12 @@ class Block(object):
                 self[i1 - 1, i2].sha1,
                 msg=logmsg,
                 )
-            sys.stderr.write('success.\n')
         except AutomaticMergeFailed:
             sys.stderr.write('conflict.\n')
             self[i1, i2].record_blocked(True)
             return False
         else:
+            sys.stderr.write('success.\n')
             self[i1, i2].record_merge(merge, MergeRecord.NEW_AUTO)
             return True
 

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -2314,16 +2314,17 @@ class Block(object):
         for (i1, i2, merge) in merges:
             self[i1, i2].record_merge(merge, MergeRecord.NEW_AUTO)
 
-    def auto_fill_micromerge(self):
-        """Try to fill the very first micromerge in this block.
+    def auto_fill_micromerge(self, i1=1, i2=1):
+        """Try to fill micromerge (i1, i2) in this block (default (1, 1)).
 
         Return True iff the attempt was successful."""
 
-        assert (1, 1) not in self
-        if self.len1 <= 1 or self.len2 <= 1 or self.is_blocked(1, 1):
+        assert (i1, i2) not in self
+        assert (i1 - 1, i2) in self
+        assert (i1, i2 - 1) in self
+        if self.len1 <= i1 or self.len2 <= i2 or self.is_blocked(i1, i2):
             return False
 
-        i1, i2 = 1, 1
         (i1orig, i2orig) = self.get_original_indexes(i1, i2)
         sys.stderr.write('Attempting to merge %d-%d...' % (i1orig, i2orig))
         logmsg = 'imerge \'%s\': automatic merge %d-%d' % (self.name, i1orig, i2orig)

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -2738,13 +2738,14 @@ class MergeState(Block):
         try:
             while True:
                 frontier = self.map_frontier()
-                frontier.auto_expand()
-                self.save()
+                try:
+                    frontier.auto_expand()
+                finally:
+                    self.save()
                 progress_made = True
         except BlockCompleteError:
             return
         except FrontierBlockedError as e:
-            self.save()
             if not progress_made:
                 # Adjust the error message:
                 raise FrontierBlockedError(

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -2012,7 +2012,7 @@ class MergeFrontier(object):
         blocks.sort(key=lambda block: block.get_original_indexes(0, 0))
 
         for block in blocks:
-            if block.auto_expand_frontier():
+            if block.auto_fill():
                 return
         else:
             # None of the blocks could be expanded.  Suggest that the
@@ -2277,24 +2277,25 @@ class Block(object):
             self[i1, i2].record_merge(merge, MergeRecord.NEW_AUTO)
             return True
 
-    def auto_outline_frontier(self, merge_frontier=None):
-        """Try to outline the merge frontier of this block.
+    def auto_fill(self):
+        """Try to expand the merge frontier within this block.
 
-        Return True iff some progress was made."""
+        Try to "fill" part or all of this block, using only automatic
+        merges. What "fill" means depends on the goal; it might mean
+        filling in the whole block, or filling it its outline (if
+        possible), or splitting it into smaller blocks and outlining
+        those, or whatever. Return True iff some progress was made.
 
-        if merge_frontier is None:
-            merge_frontier = MergeFrontier.compute_by_bisection(self)
+        """
 
-        return merge_frontier.auto_fill()
-
-    def auto_expand_frontier(self):
         merge_state = self.get_merge_state()
         if merge_state.manual:
             return False
         elif merge_state.goal == 'full':
             return self.auto_fill_micromerge()
         else:
-            return self.auto_outline_frontier()
+            merge_frontier = MergeFrontier.compute_by_bisection(self)
+            return merge_frontier.auto_fill()
 
     # The codes in the 2D array returned from create_diagram()
     MERGE_UNKNOWN = 0

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1912,23 +1912,29 @@ class MergeFrontier(object):
             MergeFrontier(self.block[block.len1 - 1:, :block.len2], right),
             )
 
+    def iter_boundary_blocks(self):
+        """Iterate over the complete blocks that form this block's boundary.
+
+        Iterate over them from bottom left to top right. This is like
+        self.blocks, except that it also includes the implicit blocks
+        at self.block[0, :] and self.blocks[:, 0] if they are needed
+        to complete the boundary.
+
+        """
+
+        if not self or self.blocks[0].len2 < self.block.len2:
+            yield self.block[0, :]
+        for block in self:
+            yield block
+        if not self or self.blocks[-1].len1 < self.block.len1:
+            yield self.block[:, 0]
+
     def iter_blocker_blocks(self):
         """Iterate over the blocks on the far side of this frontier.
 
         This must only be called for an outlined frontier."""
 
-        if not self:
-            yield self.block
-            return
-
-        blockruns = []
-        if self.blocks[0].len2 < self.block.len2:
-            blockruns.append([self.block[0, :]])
-        blockruns.append(self)
-        if self.blocks[-1].len1 < self.block.len1:
-            blockruns.append([self.block[:, 0]])
-
-        for block1, block2 in iter_neighbors(itertools.chain(*blockruns)):
+        for block1, block2 in iter_neighbors(self.iter_boundary_blocks()):
             yield self.block[block1.len1 - 1:block2.len1, block2.len2 - 1: block1.len2]
 
     def get_affected_blocker_block(self, i1, i2):

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1957,7 +1957,7 @@ class BlockwiseMergeFrontier(MergeFrontier):
         Return True iff some progress was made."""
 
         while self:
-            best_block = max(self, key=lambda block: block.get_original_indexes(0, 0))
+            best_block = min(self, key=lambda block: (block.len1, block.len2))
 
             try:
                 best_block.auto_outline()

--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1756,7 +1756,7 @@ class BlockwiseMergeFrontier(MergeFrontier):
                             break
 
     @staticmethod
-    def compute_by_bisection(block):
+    def initiate_merge(block):
         """Return a BlockwiseMergeFrontier instance for block.
 
         Compute the blocks making up the boundary using bisection. See
@@ -2334,7 +2334,7 @@ class Block(object):
         elif merge_state.goal == 'full':
             return self.auto_fill_micromerge()
         else:
-            merge_frontier = BlockwiseMergeFrontier.compute_by_bisection(self)
+            merge_frontier = BlockwiseMergeFrontier.initiate_merge(self)
             return merge_frontier.auto_fill()
 
     # The codes in the 2D array returned from create_diagram()


### PR DESCRIPTION
Let's use the `MergeFrontier` abstraction as the level to distinguish between different filling algorithms. Add the following variants:

* `FullMergeFrontier`
* `ManualMergeFrontier`
* `BlockwiseMergeFrontier`

Move the code that is specific to each algorithm into the corresponding class (instead of relying on conditional logic in a single `MergeFrontier` class, as before).

This is a prelude to adding a new `MergeFrontier` type that is optimized for rebasing short branches across lots of main branch revisions.

It'd be nice to add some tests of `ManualMergeFrontier`.
