### PR TITLE
If `completionsdir` is not configured, just skip installing completions

### DIFF
--- a/gitimerge.py
+++ b/gitimerge.py
@@ -1891,8 +1891,7 @@ class BlockwiseMergeFrontier(MergeFrontier):
                     # the indexes):
                     (i1orig, i2orig) = subblock.get_original_indexes(e.i1, e.i2)
                     top_level_frontier.remove_failure(
-                        *block.convert_original_indexes(i1orig, i2orig),
-                        )
+                        *block.convert_original_indexes(i1orig, i2orig))
                 # Restart loop for the same frontier...
             else:
                 # We're only interested in subfrontiers that contain

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ try:
 except OSError as e:
     if e.errno != errno.ENOENT:
         raise
+except subprocess.CalledProcessError:
+    # `bash-completion` is probably not installed. Just skip it.
+    pass
 else:
     completionsdir = completionsdir.strip().decode('utf-8')
     if completionsdir:


### PR DESCRIPTION
The install was failing for some people who didn't have `bash-completion` installed. Maybe this will fix it.

Hopefully fixes #153.

/cc @kergoth, @Taytay, @mochadwi: does this fix the problem for you?
