### PR TITLE
README: mention Homebrew as a possible installation method on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ or using `setup.py` if you have downloaded the source package locally:
 
     $ python setup.py install
 
+If you are on macOS, you can use Homebrew to install `git-imerge`:
+
+    $ brew install git-imerge
 
 ## Instructions
 


### PR DESCRIPTION
This pull request adds a sentence to the `README.md` file that mentions that Homebrew can be used to install `git-imerge` on macOS.

See also:
1. https://formulae.brew.sh/formula/git-imerge
2. https://github.com/Homebrew/homebrew-core/blob/master/Formula/git-imerge.rb

cc: @mhagger