### PR TITLE
Remove support for end-of-life Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import subprocess
 
 from setuptools import setup
 
-with open("README.md", "r") as fh:
+with open("README.md") as fh:
     long_description = fh.read()
 
 data_files = []
@@ -36,17 +36,13 @@ setup(
     py_modules=["gitimerge"],
     data_files=data_files,
     entry_points={"console_scripts": ["git-imerge = gitimerge:climain"]},
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
_This is a re-sumbission of #194, which was closed due to the author deleting the fork._

The following version of Python are EOL. They are no longer receiving
bug fixes including for security issues. The following table at the
following link shows branch status with dates:
https://devguide.python.org/devcycle/#end-of-life-branches

By removing EOL Pythons, the code can take advantage of new features and
syntax. Such straightforward fixes have been applied using the tool
pyupgrade:
https://github.com/asottile/pyupgrade

Adopting new syntax will also allow for additional future improvements
such as adding type annotations.

Using pypinfo, we can see that that there are no Python 2 users through
PyPI:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.10           |  30.43% |              7 |
| 3.8            |  26.09% |              6 |
| 3.6            |  21.74% |              5 |
| 3.9            |  17.39% |              4 |
| 3.7            |   4.35% |              1 |
| Total          |         |             23 |
